### PR TITLE
fix: restore genuine P0 in security eval, test the action from the wo…

### DIFF
--- a/.github/workflows/demo-audit.yml
+++ b/.github/workflows/demo-audit.yml
@@ -18,10 +18,15 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: maheshwarimrinal/react-native-agents@v1.0.1
+
+      # `./` runs the action from this checkout, not the published release.
+      # This workflow triggers on `action/**` changes, so it must exercise the
+      # working tree — pinning to @v1.0.1 here would run the old published code
+      # and silently pass a PR that broke the action.
+      - uses: ./
         with:
           provider: openai
           model: gpt-5

--- a/evals/security/jwt-in-asyncstorage/case.json
+++ b/evals/security/jwt-in-asyncstorage/case.json
@@ -1,33 +1,41 @@
 {
   "agent": "rn-security",
-  "title": "Tokens in AsyncStorage, live Stripe secret in the bundle, PII logging, incomplete logout",
+  "title": "Live Stripe secret inlined via EXPO_PUBLIC_, tokens in AsyncStorage, PII logging, incomplete logout",
   "context": { "reactNative": "0.87", "expo": "57", "language": "TypeScript" },
 
-  "notes": "The hardcoded live secret key must be the top finding — it is the only defect here that is already compromised for every shipped install. An agent that leads with the AsyncStorage issue has mis-prioritised.",
+  "notes": "The P0 is the Stripe secret key reaching the client at all. EXPO_PUBLIC_* is inlined into the JS bundle verbatim, so the key is extractable from any shipped build with `strings` — and the client calls the Stripe API directly with it, giving any attacker refund and charge capability. Developers widely believe env vars are private, so an agent that treats this as merely 'a config smell' has missed the point. The fixture deliberately contains no key-shaped literal (it would trip secret scanners on a public repo); the agent must reason about the mechanism, not pattern-match on `sk_live`.",
 
   "expect": [
     {
-      "name": "flags the hardcoded live secret key as the most severe issue",
-      "any": ["sk_live", "stripe", "secret key", "hardcoded"]
+      "name": "identifies that the Stripe secret reaches the client bundle",
+      "any": ["stripe", "secret key", "expo_public", "bundle", "inlined", "client"]
     },
     {
-      "name": "states the key must be rotated, not just removed",
-      "any": ["rotate", "revoke", "already compromised", "regenerate"]
+      "name": "explains that EXPO_PUBLIC_ / build-time env vars are not secret",
+      "any": ["not secret", "not private", "inlined", "plaintext", "extractab", "strings", "public"]
+    },
+    {
+      "name": "states the key must be rotated, not merely removed from source",
+      "any": ["rotate", "revoke", "already compromised", "regenerate", "already shipped"]
+    },
+    {
+      "name": "recommends proxying the Stripe call through a backend",
+      "any": ["backend", "server", "proxy", "never leave", "server-side"]
     },
     {
       "name": "flags tokens in unencrypted AsyncStorage",
       "any": ["asyncstorage", "unencrypted", "not encrypted", "plaintext"]
     },
     {
-      "name": "recommends Keychain / Keystore / SecureStore",
+      "name": "recommends Keychain / Keystore / SecureStore for tokens",
       "any": ["keychain", "keystore", "securestore", "expo-secure-store", "encryptedsharedpreferences"]
     },
     {
-      "name": "flags the token and PII being logged",
+      "name": "flags the access token and PII being logged",
       "any": ["console.log", "logging", "logcat", "log"]
     },
     {
-      "name": "notes logout does not clear everything",
+      "name": "notes logout leaves the refresh token and user data behind",
       "any": ["logout", "refresh_token", "still", "clear", "revoke"]
     },
     {
@@ -44,13 +52,17 @@
       "pattern": "asyncstorage\\s+(is\\s+)?(encrypted|secure|safe)"
     },
     {
-      "name": "suggests obfuscation as a fix for the shipped secret",
-      "all": ["obfuscat"],
-      "unless": ["not a", "does not", "insufficient", "only raises", "defence in depth", "defense in depth"]
+      "name": "treats EXPO_PUBLIC_ / env vars as a safe place for a secret",
+      "pattern": "(expo_public|environment variable|env var)\\w*\\s*(is|are|remains?)\\s+\\w*\\s*(secure|safe|secret|private|hidden|protected)"
     },
     {
-      "name": "treats EXPO_PUBLIC_ env vars as secret",
-      "pattern": "(expo_public|env\\s+var\\w*)\\s+\\w*\\s*(is|are)\\s+(secure|safe|secret|hidden)"
+      "name": "suggests obfuscation as the fix for a shipped secret",
+      "all": ["obfuscat"],
+      "unless": ["not a", "does not", "insufficient", "only raises", "defence in depth", "defense in depth", "not a substitute"]
+    },
+    {
+      "name": "suggests moving the key to a non-EXPO_PUBLIC var as a sufficient fix",
+      "pattern": "(rename|move|change)\\s+\\w*\\s*(it\\s+)?to\\s+a?\\s*(non-)?expo_public\\w*\\s*(and|which)?\\s*(is|will be)?\\s*(secure|safe|fixed|solved)"
     },
     {
       "name": "invents a CVE identifier",

--- a/evals/security/jwt-in-asyncstorage/input.ts
+++ b/evals/security/jwt-in-asyncstorage/input.ts
@@ -1,7 +1,26 @@
+// FIXTURE NOTE — deliberately contains no realistic-looking key literal.
+// A string shaped like `sk_live_<24+ chars>` would trip GitHub secret scanning
+// and gitleaks on this public repo, so the P0 here is expressed the way the
+// mistake usually reaches production anyway: a live secret injected at build
+// time through an EXPO_PUBLIC_* variable, which developers widely believe is
+// private and which Expo inlines verbatim into the JS bundle.
+// Do not "restore realism" by pasting a key-shaped literal here.
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL;
-const STRIPE_SECRET = 'EXAMPLE_STRIPE_SECRET';
+
+// Set in CI from the production Stripe restricted-to-nothing key.
+// Charges and refunds are issued directly from the app.
+const STRIPE_SECRET_KEY = process.env.EXPO_PUBLIC_STRIPE_SECRET_KEY!;
+
+export async function refund(chargeId: string, amountCents: number) {
+  return fetch('https://api.stripe.com/v1/refunds', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${STRIPE_SECRET_KEY}` },
+    body: new URLSearchParams({ charge: chargeId, amount: String(amountCents) }),
+  });
+}
 
 export async function login(email: string, password: string) {
   const res = await fetch(`${API_BASE}/auth/login`, {

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -637,6 +637,47 @@ test('eval scoring accepts a measured answer mentioning FlashList', () => {
   eq(good.violations.length, 0, `unexpected violations: ${good.violations.map((v) => v.name).join(', ')}`);
 });
 
+test('eval fixtures contain no scanner-triggering credential literals', () => {
+  // A realistic-looking key in a public repo trips GitHub secret scanning and
+  // gitleaks — and is a bad look in the repo whose own security agent forbids it.
+  const patterns = [
+    /sk_live_[A-Za-z0-9]{12,}/,
+    /sk_test_[A-Za-z0-9]{12,}/,
+    /AKIA[0-9A-Z]{16}/,
+    /ghp_[A-Za-z0-9]{20,}/,
+    /AIza[0-9A-Za-z_-]{30,}/,
+    /xox[baprs]-[A-Za-z0-9-]{10,}/,
+  ];
+  for (const c of evalCases) {
+    for (const p of patterns) {
+      const m = c.input.match(p);
+      assert(!m, `${c.id} contains a scanner-triggering literal: ${m?.[0]?.slice(0, 12)}…`);
+    }
+  }
+});
+
+test('the security fixture still expresses a genuine P0, not a defanged placeholder', () => {
+  // Redacting the literal must not quietly turn the case into one that a
+  // *correct* agent fails — a transparent placeholder is not a P0, so demanding
+  // P0 + "rotate" would reward over-reacting instead of good judgement.
+  const c = evalCases.find((x) => x.id === 'security/jwt-in-asyncstorage');
+  assert(c, 'security eval case missing');
+
+  const defanged = /=\s*['"](EXAMPLE|PLACEHOLDER|CHANGEME|TODO|XXX)[_A-Z]*['"]/.test(c.input);
+  assert(
+    !defanged,
+    'fixture uses a transparent placeholder — a correct agent would rate it low, ' +
+      'so expectSeverity P0 would fail good behaviour. Express the P0 by mechanism instead.',
+  );
+
+  if (c.def.expectSeverity?.includes('P0')) {
+    assert(
+      /EXPO_PUBLIC_\w*(SECRET|KEY|TOKEN)|api\.stripe\.com|authorization/i.test(c.input),
+      'case demands P0 but the fixture has no mechanism that justifies one',
+    );
+  }
+});
+
 test('eval scoring catches the AsyncStorage-is-encrypted claim', () => {
   const def = evalCases.find((c) => c.id === 'security/jwt-in-asyncstorage').def;
   const bad = scoreOutput('AsyncStorage is encrypted so the token is safe there.', def);
@@ -651,6 +692,35 @@ test('gitignore covers FUSE artifacts and packed tarballs', () => {
   const gi = fs.readFileSync(path.join(ROOT, '.gitignore'), 'utf8');
   assert(gi.includes('.fuse_hidden'), 'FUSE artifacts must be ignored');
   assert(gi.includes('*.tgz'), 'packed tarballs must be ignored');
+});
+
+test('third-party actions are pinned to a commit SHA, not a mutable tag', () => {
+  // The repo's own security agent tells users to do this (supply-chain.md);
+  // failing to follow our own advice is both a risk and a credibility problem.
+  const dir = path.join(ROOT, '.github/workflows');
+  for (const f of fs.readdirSync(dir)) {
+    const src = fs.readFileSync(path.join(dir, f), 'utf8');
+    for (const [, ref] of src.matchAll(/uses:\s*([^\s#]+)/g)) {
+      if (ref.startsWith('./')) continue; // local action — no pinning needed
+      const [, version] = ref.split('@');
+      assert(
+        /^[0-9a-f]{40}$/.test(version ?? ''),
+        `${f}: "${ref}" is not pinned to a full commit SHA`,
+      );
+    }
+  }
+});
+
+test('the demo workflow exercises the working tree, not a published release', () => {
+  // It triggers on action/** changes, so pinning it to a published tag would
+  // let a PR that breaks the action pass its own demo.
+  const src = fs.readFileSync(path.join(ROOT, '.github/workflows/demo-audit.yml'), 'utf8');
+  if (/paths:[\s\S]*?action\//.test(src)) {
+    assert(
+      /uses:\s*\.\/\s*$/m.test(src),
+      'demo-audit.yml triggers on action/** but does not run `uses: ./`',
+    );
+  }
 });
 
 test('CI triggers on both main and master', () => {


### PR DESCRIPTION
Redacting the Stripe key was right for secret scanning, but it silently inverted the security eval: the case still demanded P0 severity and "rotate the key" while the fixture read EXAMPLE_STRIPE_SECRET. A correct agent would call that a placeholder and rate it low, so the case failed good judgement and rewarded over-reacting to placeholders.

Express the P0 through mechanism instead of a literal: a live Stripe secret injected via EXPO_PUBLIC_STRIPE_SECRET_KEY and used to call the Stripe API directly from the client. Scanner-safe, and it tests deeper knowledge -- build-time env inlining is the mistake developers actually make and believe is safe.

Also:
- demo-audit.yml triggered on action/** but ran the published @v1.0.1, so a PR breaking the action would pass its own demo. Now uses: ./
- Pin actions/checkout to a SHA there; every other workflow already did, and supply-chain.md tells users tags are mutable.

Adds 4 guard tests (196 total): no scanner-triggering literals in fixtures, no defanged placeholder behind a P0 expectation, third-party actions pinned to SHAs, and the demo workflow must exercise the working tree.