### PR TITLE
release: 1.0.3 with regenerated dist/ and a version-bump guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The GitHub Action reviews changed files using the relevant specialists and posts
 
 ```yaml
 - name: React Native audit
-  uses: maheshwarimrinal/react-native-agents@v1.0.2
+  uses: maheshwarimrinal/react-native-agents@v1.0.3
   with:
     provider: anthropic
     model: claude-sonnet-5
@@ -58,7 +58,7 @@ OpenAI is also supported:
 
 ```yaml
 - name: React Native audit
-  uses: maheshwarimrinal/react-native-agents@v1.0.2
+  uses: maheshwarimrinal/react-native-agents@v1.0.3
   with:
     provider: openai
     model: gpt-5

--- a/dist/claude-code/.claude-plugin/marketplace.json
+++ b/dist/claude-code/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Expert React Native agents for performance, security, quality, a11y, testing, and release.",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "plugins": [
     {
       "name": "react-native-agents",
       "source": "./plugins/react-native-agents",
       "description": "Six specialist React Native agents: performance, security, code quality, UI/accessibility, testing, and release.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "development",
       "keywords": [
         "react-native",

--- a/dist/claude-code/plugins/react-native-agents/.claude-plugin/plugin.json
+++ b/dist/claude-code/plugins/react-native-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-agents",
   "description": "Six specialist React Native agents: performance, security, code quality, UI/accessibility, testing, and release.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "keywords": [
     "react-native",

--- a/dist/index.json
+++ b/dist/index.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": null,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "knowledge": {
     "$comment": "Freshness metadata for the React Native knowledge in agents/ and shared/. This is the single source of truth for 'what have we actually checked?'. The scheduled freshness workflow compares these against the live npm registry and opens an issue when they fall behind. Update `last_verified` only after genuinely reviewing the affected references — bumping the date without reading is worse than leaving it stale, because it launders an unchecked claim as a verified one.",
     "last_verified": "2026-08-12",

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: maheshwarimrinal/react-native-agents@v1.0.2
+      - uses: maheshwarimrinal/react-native-agents@v1.0.3
         with:
           provider: anthropic
           model: claude-sonnet-5
@@ -32,7 +32,7 @@ jobs:
 For OpenAI:
 
 ```yaml
-- uses: maheshwarimrinal/react-native-agents@v1.0.2
+- uses: maheshwarimrinal/react-native-agents@v1.0.3
   with:
     provider: openai
     model: gpt-5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maheshwarimrinal/react-native-agents",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Expert React Native agents for build failures, implementation, performance, security, code quality, accessibility, testing, native modules, and release — plus a deterministic bundle-size analyzer. Portable across Claude Code, Cursor, Windsurf, Copilot, Codex, MCP clients, and GitHub Actions.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "install-agents": "node scripts/cli.mjs install",
     "mcp": "node mcp-server/index.mjs",
     "audit": "node action/index.mjs",
+    "version": "node scripts/build.mjs && git add dist",
     "prepublishOnly": "node scripts/build.mjs --check && node scripts/test.mjs && node action/test.mjs",
     "evals": "node evals/run.mjs",
     "evals:validate": "node evals/run.mjs --validate",


### PR DESCRIPTION
Fixes the failed `v1.0.3` publish run and prevents the same failure recurring.

## What broke

`npm version patch` bumps `package.json` but does not run the generator, and the generated plugin metadata embeds the version. The publish workflow failed its first step:

```
✗ dist/ is out of sync with agents/ (3 file(s))

  stale:    claude-code/.claude-plugin/marketplace.json
  stale:    claude-code/plugins/react-native-agents/.claude-plugin/plugin.json
  stale:    index.json
```

Nothing reached npm — the check runs before publish, so the registry is still on 1.0.2.

## Changes

- Regenerate `dist/` so the embedded version matches 1.0.3
- Bump the four documented `uses: maheshwarimrinal/react-native-agents@v1.0.2` pins in `README.md` and `docs/github-action.md` to `v1.0.3`
- Add a `version` lifecycle script (`node scripts/build.mjs && git add dist`) so future bumps regenerate and stage `dist/` in the same commit

## Verification

```
✓ dist/ is in sync (298 files)
✓ 252 passed
✓ 116 passed
```

After merge, `v1.0.3` needs re-pointing at the merge commit — it currently points at a commit that cannot build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)