### PR TITLE
ci: make the publish workflow work with npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,9 @@ name: Publish to npm
 # Publishes when a version tag is pushed:
 #   npm version patch && git push --follow-tags
 #
-# Requires an NPM_TOKEN secret: an npm "Automation" access token
-# (npmjs.com → Access Tokens → Generate → Automation), which bypasses 2FA
-# for CI while still requiring 2FA for interactive publishes.
+# Authentication is an npm trusted publisher (OIDC) bound to this repository and
+# this workflow file, configured at npmjs.com → package → Settings → Trusted
+# Publisher. No long-lived token is stored in repository secrets.
 on:
   push:
     tags: ['v*']
@@ -28,8 +28,16 @@ jobs:
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      # OIDC trusted publishing needs npm >= 11.5.1. Older npm silently skips the
+      # token exchange and fails with ENEEDAUTH instead, so pin the floor here
+      # rather than relying on whichever npm the Node release happens to bundle.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       # No dependencies by design, so there is nothing to install.
       - name: Verify dist/ is in sync with agents/
@@ -60,11 +68,12 @@ jobs:
               console.log('files:', f.entryCount, '| unpacked:', (f.unpackedSize/1024/1024).toFixed(2)+'MB');
             });"
 
+      # Authentication comes from the npm trusted publisher (OIDC) configured for
+      # this package, using the id-token permission above. No NPM_TOKEN secret is
+      # involved, and provenance is attested from the workflow identity.
       - name: Publish
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         if: success()


### PR DESCRIPTION
The `v1.0.3` publish run failed at the publish step even though a trusted publisher is configured for the package:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

## Cause

OIDC trusted publishing requires npm >= 11.5.1. The job pinned `node-version: 20`, which bundles npm 10.x — that npm never attempts the OIDC token exchange and falls straight through to asking for stored credentials. The `NODE_AUTH_TOKEN` env also pointed at an `NPM_TOKEN` secret that does not exist in this repo, so it resolved to an empty string.

## Changes

- Publish job moves to Node 24, plus an explicit `npm install -g npm@latest` so the npm floor does not depend on whichever version a Node release happens to bundle
- Remove the `NODE_AUTH_TOKEN` env; auth now comes from the trusted publisher via the existing `id-token: write` permission
- Header comment now documents the trusted publisher instead of the removed token

`--provenance` is unchanged and is now attested from the workflow identity.

After merge, `v1.0.3` needs re-pointing at the merge commit, since tag-triggered runs use the workflow from the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)