### PR TITLE
ci: read npm pack --json output from both npm 11 and npm 12 shapes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,9 @@ jobs:
           echo "--- files that will ship ---"
           npm pack --dry-run --json | node -e "
             let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
-              const f=JSON.parse(d)[0];
+              // npm <= 11 emits an array; npm 12 emits an object keyed by package name.
+              const j=JSON.parse(d);
+              const f=Array.isArray(j)?j[0]:Object.values(j)[0];
               console.log('name:', f.name, f.version);
               console.log('files:', f.entryCount, '| unpacked:', (f.unpackedSize/1024/1024).toFixed(2)+'MB');
             });"


### PR DESCRIPTION
Follow-up to #9. Upgrading npm so trusted publishing works moved the job to npm 12, which changed `npm pack --dry-run --json` from an array to an object keyed by package name. The tarball inspection step assumed the array:

```
TypeError: Cannot read properties of undefined (reading 'name')
    at Socket.<anonymous> ([eval]:4:28)
```

Reads the first entry from either shape. Verified locally against both:

| npm | Output |
|---|---|
| 10.9.2 | `name: @maheshwarimrinal/react-native-agents 1.0.3` · `files: 410 \| unpacked: 3.19MB` |
| 12.0.2 | `name: @maheshwarimrinal/react-native-agents 1.0.3` · `files: 410 \| unpacked: 3.19MB` |

After merge, `v1.0.3` needs re-pointing at the merge commit again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)