### PR TITLE
feat: rn-animation agent; correct thread model, routing gaps, perform…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and prepare Marketplace release
 
 # Publishes when a version tag is pushed:
 #   npm version patch && git push --follow-tags
@@ -136,3 +136,45 @@ jobs:
               echo "\`dry_run: false\`, or push a \`v$V\` tag, to publish."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # GitHub does not expose the "Publish this Action to the GitHub Marketplace"
+  # checkbox through its public Releases API. Prepare the exact draft release
+  # automatically after npm succeeds, then leave only the Marketplace checkbox,
+  # categories, and 2FA confirmation for the maintainer in the web UI.
+  prepare-marketplace-release:
+    name: Prepare Marketplace release
+    needs: publish
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; leaving it unchanged."
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              --generate-notes \
+              --title "React Native Agents $TAG"
+          fi
+
+          EDIT_URL="https://github.com/$GITHUB_REPOSITORY/releases/edit/$TAG"
+          {
+            echo "### Marketplace release prepared for \`$TAG\`"
+            echo ""
+            echo "npm was published successfully and the GitHub release draft is ready."
+            echo ""
+            echo "1. [Open the release editor]($EDIT_URL)."
+            echo '2. Select **Publish this Action to the GitHub Marketplace**.'
+            echo '3. Confirm the Marketplace categories and publish the release.'
+            echo ""
+            echo "GitHub requires this final web step and 2FA; its public Releases API"
+            echo "does not expose the Marketplace publication checkbox."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ MONETIZATION.md
 
 # Eval run output — machine- and model-specific, never committed
 evals/results.json
+
+# Local agent tooling — personal skills and settings, not part of the package.
+# Anchored to the repository root: an unanchored `.claude/` also matches the
+# generated `dist/claude-code/.claude/` tree, which must stay tracked.
+/.claude/

--- a/README.md
+++ b/README.md
@@ -81,6 +81,38 @@ outage — the audit exits non-zero rather than reporting a pass with zero findi
 that means "we did not actually look" is worse than a red one. Set `fail-on-error: false` if you
 would rather accept partial coverage.
 
+### Run the audit locally, for free
+
+The audit speaks the OpenAI wire format, so any local server that does too —
+Ollama, LM Studio, llama.cpp — can drive it. No API key, no per-review cost.
+
+```bash
+ollama serve
+ollama pull qwen2.5-coder:14b
+
+npm run audit:local                      # your uncommitted changes
+npm run audit:local -- --base main       # this branch vs main
+npm run audit:local -- --repo ~/my-app --base main
+npm run audit:local -- --model qwen2.5-coder:32b
+```
+
+**Set the context window before you trust the result.** Ollama defaults
+`num_ctx` to 4096 for most models no matter what the model supports, and on
+overflow it does not error — it silently drops the oldest tokens, which are the
+agent's instructions. You get a confident, well-formatted review of nothing, and
+a green "Passed" that means nothing. Start the server with a real window:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=32768 ollama serve
+```
+
+`audit:local` measures the prompt against the window and refuses to run rather
+than hand you a review it cannot stand behind.
+
+A 14B model finds the obvious defects and misses subtle ones — treat a local
+pass as a smoke test, not as the gate. The hosted providers remain the reference
+configuration for CI.
+
 ## The agents
 
 **Day to day** — these respond to a question, an error log, or a request:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # React Native Agents
 
-**24 expert AI agents for React Native — upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, store submission, payments, background execution, and monorepos.**
+**25 expert AI agents for React Native — upgrades, debugging, animation, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, store submission, payments, background execution, and monorepos.**
 
 Works with Claude Code, Cursor, Windsurf, GitHub Copilot, Codex, Zed, Aider, MCP clients, and GitHub Actions.
 
@@ -99,6 +99,7 @@ would rather accept partial coverage.
 
 | Agent | Focus | Command |
 |---|---|---|
+| 🎬 Animation | Reanimated worklets, gestures, layout animations | `/rn-animate` |
 | ⚡ Performance | Lists, rendering, startup, memory, bundles | `/rn-perf` |
 | 🔒 Security | Secrets, storage, auth, TLS, WebViews, deep links, supply chain | `/rn-security` |
 | 🧹 Code Quality | Architecture, TypeScript, hooks, state, errors, RN idioms | `/rn-review` |
@@ -122,7 +123,7 @@ Seven agents are deliberately excluded from pull-request routing — **Doctor, B
 
 Routing is narrow on purpose. A typical UI change reaches about three agents, not twenty-four — signals are scoped so that adding specialists does not raise the cost of an ordinary pull request.
 
-24 playbooks and 128 reference documents. Knowledge is verified through React Native 0.87 and Expo SDK 57; always verify version-specific advice against your project.
+25 playbooks and 133 reference documents. Knowledge is verified through React Native 0.87 and Expo SDK 57; always verify version-specific advice against your project.
 
 ## Bundle size, measured
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -40,7 +40,7 @@ dropped before the payload is built.
 | `tool` | `cursor`, `claude-code`, `windsurf` | Which editor the agents were installed for |
 | `agent_id` | `rn-performance` | Which specialist was loaded, from this repo's own ids |
 | `agent_count` | `3` | How many agents an audit ran |
-| `version` | `1.3.1` | This package's version |
+| `version` | `1.4.0` | This package's version |
 | `node_major` | `22` | Node major version only — not the full version string |
 | `os` | `darwin`, `linux`, `win32` | Platform only |
 | `ci` | `true` | Whether this was an automated environment |

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ inputs:
 
   agents:
     description: >-
-      Comma-separated agent ids to force. Any of the 17 review agents:
-      rn-background, rn-code-quality, rn-native-modules, rn-navigation,
+      Comma-separated agent ids to force. Any of the 18 review agents:
+      rn-animation, rn-background, rn-code-quality, rn-native-modules, rn-navigation,
       rn-observability, rn-offline, rn-payments, rn-performance,
       rn-permissions, rn-platform-parity, rn-push, rn-release, rn-security,
       rn-state, rn-testing, rn-ui-accessibility, rn-upgrade.

--- a/action/lib/audit.mjs
+++ b/action/lib/audit.mjs
@@ -279,6 +279,157 @@ export class MalformedResponseError extends Error {
  * went green having learned nothing. Only a well-formed `{"findings": [...]}`
  * counts as a review; everything else is an error the run must surface.
  */
+/**
+ * Escape raw control characters that appear *inside* JSON string literals.
+ *
+ * JSON forbids unescaped characters below U+0020 in strings, and a model
+ * writing a multi-line `fix` routinely emits a literal newline there. The
+ * document is otherwise complete, so discarding the whole review over it throws
+ * away a valid answer.
+ *
+ * Tracks string state character by character rather than using a regex, because
+ * a regex cannot tell a newline inside a string from the newline that formats
+ * the document — and escaping the latter would corrupt a valid response.
+ * Characters outside strings are left exactly as they are.
+ */
+export function escapeControlCharsInStrings(text) {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+
+  for (const ch of text) {
+    if (escaped) {
+      out += ch;
+      escaped = false;
+      continue;
+    }
+    if (inString && ch === '\\') {
+      out += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      out += ch;
+      continue;
+    }
+    if (inString && ch < ' ') {
+      const map = { '\n': '\\n', '\r': '\\r', '\t': '\\t', '\b': '\\b', '\f': '\\f' };
+      out += map[ch] ?? `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * Convert backtick-delimited values to JSON strings.
+ *
+ * A model writing a multi-line `fix` reaches for a template literal, because
+ * that is what the surrounding language uses:
+ *
+ *   "verify": `
+ *     npx react-native run-android
+ *   `
+ *
+ * The document is complete and its structure is unambiguous — only the quoting
+ * is wrong. Converting is mechanical: escape what JSON requires escaping and
+ * change the delimiters. Only backticks that sit where a *value* belongs are
+ * touched (after `:` or `[` or `,`), so a backtick inside an ordinary
+ * double-quoted string is left alone.
+ */
+export function backtickStringsToJson(text) {
+  let out = '';
+  let i = 0;
+  let inString = false;
+  let escaped = false;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '`') {
+      // Find the closing backtick, honouring backslash escapes.
+      let j = i + 1;
+      let body = '';
+      while (j < text.length) {
+        if (text[j] === '\\' && j + 1 < text.length) {
+          body += text[j] + text[j + 1];
+          j += 2;
+          continue;
+        }
+        if (text[j] === '`') break;
+        body += text[j];
+        j += 1;
+      }
+      if (j >= text.length) {
+        // Unterminated — not something to guess at.
+        out += text.slice(i);
+        break;
+      }
+      out += JSON.stringify(body);
+      i = j + 1;
+      continue;
+    }
+
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Remove a comma that immediately precedes `}` or `]`.
+ *
+ * Legal in JavaScript, not in JSON, and models trained on JavaScript emit it.
+ * Whitespace and newlines between the comma and the bracket are allowed for.
+ * String contents are skipped so a comma inside prose survives.
+ */
+export function stripTrailingCommas(text) {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === ',') {
+      const rest = text.slice(i + 1);
+      if (/^\s*[}\]]/.test(rest)) continue; // drop it
+    }
+    out += ch;
+  }
+  return out;
+}
+
 export function parseFindings(raw) {
   const empty = { findings: [], summary: '' };
   if (!raw || typeof raw !== 'string' || !raw.trim()) {
@@ -303,7 +454,66 @@ export function parseFindings(raw) {
   try {
     parsed = JSON.parse(text);
   } catch (error) {
-    throw new MalformedResponseError(`invalid JSON (${error.message}) — likely truncated`, raw);
+    /**
+     * One safe repair, then an honest diagnosis.
+     *
+     * A model writing a multi-line `fix` very often emits a literal newline
+     * inside the JSON string rather than `\n`. That is not truncation — the
+     * document is complete and well-formed apart from characters that JSON
+     * happens to forbid unescaped. Escaping control characters *inside string
+     * literals* is deterministic and cannot change the parsed values, so it is
+     * worth one attempt before discarding a whole agent's review.
+     *
+     * Nothing else is repaired. Guessing at a missing brace would mean
+     * inventing content, and a review assembled from a guess is exactly the
+     * false green this package exists to avoid.
+     */
+    /**
+     * Applied in order, each strictly structural. None of them can change a
+     * value that already parsed, and none invent content: a missing brace is
+     * still a hard failure, because assembling a review from a guess is the
+     * false green this package exists to avoid.
+     */
+    /**
+     * One composed repair, not a chain of alternatives.
+     *
+     * Each step is a no-op on input that does not contain its trigger, so
+     * applying all three is equivalent to trying them in turn — and a chain
+     * whose last entry is the composition of the others has entries that can
+     * never change the outcome. A mutation removing two of them left the suite
+     * green, which is how that was found.
+     *
+     * Every step is strictly structural: none can change a value that already
+     * parsed, and none invent content. A missing brace is still a hard failure,
+     * because assembling a review from a guess is the false green this package
+     * exists to avoid.
+     */
+    let candidate = text;
+    try {
+      candidate = stripTrailingCommas(backtickStringsToJson(escapeControlCharsInStrings(text)));
+    } catch {
+      candidate = text;
+    }
+    if (candidate !== text) {
+      try {
+        parsed = JSON.parse(candidate);
+      } catch {
+        /* fall through to the error below */
+      }
+    }
+
+    if (parsed === undefined) {
+      /**
+       * Truncation and bad escaping are different failures with different
+       * fixes — raise the context window versus tighten the prompt — and
+       * labelling everything "likely truncated" sent people to the wrong one.
+       */
+      const looksTruncated = !/\}\s*$/.test(text);
+      const cause = looksTruncated
+        ? 'likely truncated — the response does not end with a closing brace'
+        : 'the response is complete but not valid JSON';
+      throw new MalformedResponseError(`invalid JSON (${error.message}) — ${cause}`, raw);
+    }
   }
 
   if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.findings)) {

--- a/action/lib/llm.mjs
+++ b/action/lib/llm.mjs
@@ -97,6 +97,8 @@ export class LLM {
     budgetUsd = 2,
     maxOutputTokens = 8000,
     baseUrl,
+    temperature,
+    seed,
     log = () => {},
   }) {
     // A typo like 'opneai' previously selected the Anthropic key and the Claude
@@ -139,6 +141,23 @@ export class LLM {
     this.budgetUsd = budgetUsd;
     this.pricingKnown = this.isLocal || provider === 'mock' || PRICED_MODELS.has(model);
     this.maxOutputTokens = maxOutputTokens;
+
+    /**
+     * Sampling controls, sent only when set.
+     *
+     * Nothing set temperature at all, so every run used the provider's default
+     * — 0.8 on Ollama. Two eval runs over identical inputs produced 3/16 and
+     * 8/16 clean-case failures, and that spread was read as model capability
+     * when most of it was sampling noise.
+     *
+     * Sent conditionally rather than defaulted here, because it is not
+     * universally accepted: OpenAI's reasoning models reject any temperature
+     * other than 1, so a blanket `temperature: 0` would break them. The eval
+     * runner opts in for local endpoints, where determinism is both wanted and
+     * available.
+     */
+    this.temperature = temperature;
+    this.seed = seed;
     this.log = log;
     // Surfaced rather than silent: a budget computed from a guessed price is an
     // estimate with a wide error bar, and the caller should know which it has.
@@ -226,6 +245,8 @@ export class LLM {
       body: JSON.stringify({
         model: this.model,
         max_completion_tokens: this.maxOutputTokens,
+        ...(this.temperature === undefined ? {} : { temperature: this.temperature }),
+        ...(this.seed === undefined ? {} : { seed: this.seed }),
         messages: [
           { role: 'system', content: system },
           { role: 'user', content: user },

--- a/action/lib/router.mjs
+++ b/action/lib/router.mjs
@@ -112,9 +112,37 @@ export const SIGNALS = {
     '**/*{webview,WebView,deeplink,DeepLink,linking,Linking}*.{ts,tsx,js,jsx}',
     '**/*{api,Api,API,fetch,client,Client,http,Http}*.{ts,tsx,js,jsx}',
   ],
+  'rn-animation': [
+    '**/*{Animated,animated,Animation,animation,Reanimated,reanimated}*.{ts,tsx,js,jsx}',
+    // Whole words, not prefixes. `Pan` matched PanelHeader, Companion and Panda;
+    // `Motion` matched Promotion, Demotion, Emotion and Locomotion — the same
+    // shape as the `profil*` bug that routed "edit profile avatar" to
+    // rn-performance.
+    //
+    // Note that dropping a filename pattern is NOT free. Trigger matching runs
+    // against *added* lines only, so an existing animated file whose import
+    // block is untouched contributes no Reanimated text to the diff at all: a
+    // one-line opacity change in ScreenTransition.tsx has no `reanimated`
+    // anywhere in it. Filename signals are the only thing that catches edits to
+    // files that were already animated.
+    '**/*{Gesture,gesture,Swipe,swipe,Draggable,draggable,Pinch,pinch}*.{ts,tsx,js,jsx}',
+    '**/*{Carousel,carousel,Parallax,parallax,Skeleton,skeleton}*.{ts,tsx,js,jsx}',
+    // `Transition` as a whole word, anchored so it cannot match "Transitional".
+    // Dropping it entirely lost files like ScreenTransition.tsx, and the claim
+    // that diff-content triggers would catch them was wrong: the router only
+    // sees *added* lines, so editing one line of an existing animated file
+    // never re-adds its import.
+    '**/*Transition.{ts,tsx,js,jsx}',
+    '**/*Transitions.{ts,tsx,js,jsx}',
+    '**/babel.config.js',
+  ],
+
   'rn-performance': [
     '**/*{List,list,Feed,feed,Scroll,scroll,Grid,grid}*.{ts,tsx,js,jsx}',
-    '**/*{Animated,animation,Animation,gesture,Gesture,Reanimated}*.{ts,tsx,js,jsx}',
+    // The animation/gesture glob moved to rn-animation, which owns whether the
+    // code is *correct*. Performance still routes on the keyword signals below
+    // ("janky", "dropped frames"), so a genuine frame-budget question still
+    // reaches it — but a file named Reanimated*.tsx is an authoring question.
     '**/*{Image,image,Video,video,Media,media}*.{ts,tsx,js,jsx}',
     '**/metro.config.js',
     '**/babel.config.js',
@@ -430,7 +458,30 @@ const BACKGROUND_KEYS = new RegExp(
   'i',
 );
 
+/**
+ * Reanimated/Worklets mentions in a Babel config.
+ *
+ * `babel.config.js` is a signal for several agents, so an unrelated edit — a
+ * module-resolver alias, a env-specific plugin — used to wake the animation
+ * agent and spend a full review on it.
+ */
+const WORKLETS_BABEL_KEYS =
+  /react-native-(reanimated|worklets)|worklets\/plugin|reanimated\/plugin|processNestedWorklets|globals.*worklet/i;
+
 export const REFINEMENTS = {
+  'rn-animation': (file, diffText) => {
+    if (!/(^|\/)babel\.config\.[cm]?js$/.test(file)) return true;
+    if (!diffText) return true; // fail open
+    // Both signs. Deleting the worklets plugin is the single most destructive
+    // edit this file can carry, and it appears only as a removed line.
+    const changed = [
+      ...addedLinesForFile(diffText, file),
+      ...removedLinesForFile(diffText, file),
+    ];
+    if (changed.length === 0) return true;
+    return WORKLETS_BABEL_KEYS.test(changed.join('\n'));
+  },
+
   'rn-background': (file, diffText) => {
     // Only native config files are gated; source-file signals are specific
     // enough already.
@@ -563,12 +614,38 @@ export function route(changedFiles, agents, opts = {}) {
  * version string was enough to route rn-upgrade on a pull request whose
  * package.json only added lodash.
  */
+/**
+ * Lines *removed* from one file, by the same attribution rules as
+ * addedLinesForFile.
+ *
+ * Deletions carry signal that additions do not. Removing
+ * `react-native-worklets/plugin` from a Babel config silently breaks every
+ * worklet in the app, and a refinement reading only added lines sees an
+ * unrelated plugin being added and skips the review.
+ */
+export function removedLinesForFile(diffText, filePath) {
+  return diffLinesForFile(diffText, filePath, '-');
+}
+
 export function addedLinesForFile(diffText, filePath) {
   // A diff without any `diff --git` framing cannot be attributed per file —
   // a raw --diff-file, or a hunk pasted by hand. Falling back to every added
   // line is the fail-open choice: mis-attributing a keyword is recoverable,
   // losing every keyword signal is not.
-  if (!/^diff --git /m.test(diffText)) return addedLines(diffText);
+  return diffLinesForFile(diffText, filePath, '+');
+}
+
+function diffLinesForFile(diffText, filePath, sign) {
+  if (!diffText) return [];
+  if (!/^diff --git /m.test(diffText)) {
+    // Unframed diff: fall open for additions (see above). Deletions have no
+    // equivalent whole-diff helper, so scan every line of the same sign.
+    if (sign === '+') return addedLines(diffText);
+    return diffText
+      .split('\n')
+      .filter((l) => l.startsWith('-') && !l.startsWith('---'))
+      .map((l) => l.slice(1));
+  }
 
   const out = [];
   let inFile = false;
@@ -582,7 +659,7 @@ export function addedLinesForFile(diffText, filePath) {
     }
     if (!inFile) continue;
     if (line.startsWith('+++') || line.startsWith('---')) continue;
-    if (line.startsWith('+')) out.push(line.slice(1));
+    if (line.startsWith(sign)) out.push(line.slice(1));
   }
   return out;
 }

--- a/action/test.mjs
+++ b/action/test.mjs
@@ -20,7 +20,7 @@ const { parseDiff, renderForPrompt, findPosition, nearestChangedLine, changedFil
   await import('./lib/diff.mjs');
 const { LLM, estimateTokens, estimateCost, BudgetExceededError, PRICING } = await import('./lib/llm.mjs');
 const awaitedAudit = await import('./lib/audit.mjs');
-const { parseFindings, dedupe, countBySeverity, gateFails, FAIL_ON_VALUES, DIFF_FENCE, UNTRUSTED_INPUT_NOTICE } = awaitedAudit;
+const { parseFindings, dedupe, countBySeverity, gateFails, FAIL_ON_VALUES, DIFF_FENCE, UNTRUSTED_INPUT_NOTICE, escapeControlCharsInStrings, stripTrailingCommas, backtickStringsToJson } = awaitedAudit;
 const { renderSummary } = await import('./lib/github.mjs');
 const { detectProject, firstNonEmpty } = await import('./index.mjs');
 const { loadAgents } = await import('../scripts/lib/source.mjs');
@@ -525,6 +525,151 @@ test('upgrade refinement ignores routine Expo module adds', () => {
     const ids = route(['package.json'], agents, { diffText: hunk(toolchain) }).selected.map((a) => a.id);
     assert(ids.includes('rn-upgrade'), `${toolchain.trim()} should route: ${ids.join(', ')}`);
   }
+});
+
+testAsync('sampling controls are sent only when set', async () => {
+  // Nothing set temperature, so every run used the provider default — 0.8 on
+  // Ollama. Two eval sweeps over identical inputs gave 3/16 and 8/16 clean-case
+  // failures, and that spread was read as model capability.
+  //
+  // Sent conditionally because it is not universally accepted: OpenAI's
+  // reasoning models reject any temperature other than 1, so a blanket default
+  // here would break them.
+  const bodies = [];
+  const server = http.createServer((req, res) => {
+    let b = '';
+    req.on('data', (c) => (b += c));
+    req.on('end', () => {
+      bodies.push(JSON.parse(b));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        choices: [{ message: { content: '{"findings":[]}' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }));
+    });
+  });
+  await new Promise((r) => server.listen(0, r));
+  const base = `http://127.0.0.1:${server.address().port}/v1`;
+
+  try {
+    await new LLM({ provider: 'openai', apiKey: 'k', model: 'm', baseUrl: base })
+      .complete({ system: 's', user: 'u' });
+    assert(!('temperature' in bodies[0]), 'unset temperature must be omitted entirely');
+    assert(!('seed' in bodies[0]), 'unset seed must be omitted entirely');
+
+    await new LLM({ provider: 'openai', apiKey: 'k', model: 'm', baseUrl: base, temperature: 0, seed: 7 })
+      .complete({ system: 's', user: 'u' });
+    eq(bodies[1].temperature, 0);
+    eq(bodies[1].seed, 7);
+
+    // 0 is falsy — an `if (this.temperature)` guard would drop exactly the
+    // value that matters most.
+    assert(bodies[1].temperature === 0, 'temperature 0 must survive a falsy check');
+  } finally {
+    server.close();
+  }
+});
+
+test('a template literal used as a JSON value is converted', () => {
+  // Observed: a model writing a multi-line shell command reached for a template
+  // literal, because that is what the surrounding language uses.
+  const raw = '{"findings":[{"severity":"P2","title":"A","fix":`npx react-native run-android`}]}';
+  const { findings } = parseFindings(raw);
+  eq(findings.length, 1);
+  eq(findings[0].fix, 'npx react-native run-android');
+});
+
+test('a backtick inside an ordinary string is left alone', () => {
+  // Only backticks standing where a value belongs are converted. A backtick in
+  // prose — `useEffect`, say — is content, and rewriting it would corrupt a
+  // response that parsed perfectly well.
+  const src = '{"a":"call `useEffect` here"}';
+  eq(backtickStringsToJson(src), src);
+  eq(JSON.parse(backtickStringsToJson(src)).a, 'call `useEffect` here');
+});
+
+test('a trailing comma is dropped, but not one inside a string', () => {
+  eq(stripTrailingCommas('{"a":1,}'), '{"a":1}');
+  eq(stripTrailingCommas('{"a":[1,2,],}'), '{"a":[1,2]}');
+  eq(stripTrailingCommas('{"a":1 ,\n  }'), '{"a":1 \n  }');
+
+  const prose = '{"a":"one, two, three"}';
+  eq(stripTrailingCommas(prose), prose, 'commas in prose survive');
+
+  const raw = '{"findings":[{"severity":"P1","title":"A","fix":"do it",},],}';
+  eq(parseFindings(raw).findings.length, 1);
+});
+
+test('an unterminated backtick is not guessed at', () => {
+  // Repairs are structural. Inventing a closing delimiter means inventing
+  // content, and a review assembled from a guess is the false green this
+  // package exists to avoid.
+  let threw = false;
+  try {
+    parseFindings('{"findings":[{"severity":"P1","title":"A","fix":`oops}]}');
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'an unterminated template literal must still fail');
+});
+
+test('a literal newline inside a JSON string is repaired, not discarded', () => {
+  // A model writing a multi-line `fix` routinely emits a raw newline inside the
+  // string. The document is complete; only characters JSON forbids unescaped are
+  // wrong. Throwing away a whole agent's review over that loses a valid answer.
+  const raw = '{"findings":[{"severity":"P1","title":"A","why":"line one\nline two","fix":"do it"}]}';
+  const { findings } = parseFindings(raw);
+  eq(findings.length, 1);
+  eq(findings[0].why, 'line one\nline two', 'the newline survives as a real newline');
+});
+
+test('the repair never touches characters outside string literals', () => {
+  // A regex cannot tell a newline inside a string from the newline formatting
+  // the document. Escaping the latter would corrupt a response that was valid.
+  const pretty = '{\n  "a": 1,\n  "b": "x"\n}';
+  eq(escapeControlCharsInStrings(pretty), pretty, 'formatting newlines are left alone');
+
+  // And an already-escaped sequence is not double-escaped.
+  const already = '{"a":"line\\nbreak"}';
+  eq(escapeControlCharsInStrings(already), already);
+  eq(JSON.parse(escapeControlCharsInStrings(already)).a, 'line\nbreak');
+});
+
+test('truncation and invalid-but-complete JSON are diagnosed differently', () => {
+  // They have different fixes — raise the context window versus tighten the
+  // prompt — and labelling everything "likely truncated" sent people to the
+  // wrong one. A local model hitting num_ctx and a model mis-escaping a quote
+  // are not the same failure.
+  let truncated = '';
+  try {
+    parseFindings('{"findings":[{"severity":"P1","title":"A"');
+  } catch (e) {
+    truncated = e.message;
+  }
+  assert(/truncated/.test(truncated), `expected a truncation diagnosis, got: ${truncated}`);
+
+  let complete = '';
+  try {
+    parseFindings('{"findings":[{"severity":"P1","title":"A" "why":"b"}]}');
+  } catch (e) {
+    complete = e.message;
+  }
+  assert(
+    /complete but not valid JSON/.test(complete),
+    `a complete document must not be called truncated, got: ${complete}`,
+  );
+});
+
+test('the repair does not rescue genuinely broken JSON', () => {
+  // Guessing at a missing brace means inventing content, and a review assembled
+  // from a guess is the false green this package exists to avoid.
+  let threw = false;
+  try {
+    parseFindings('{"findings":[{"severity":"P1"');
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'an incomplete document must still fail');
 });
 
 test('the animation refinement reads babel.config.js content, and only that file', () => {

--- a/action/test.mjs
+++ b/action/test.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, '..');
 
-const { globToRegExp, matchesGlob, isIgnored, route, addedLines, addedLinesForFile, SIGNALS } =
+const { globToRegExp, matchesGlob, isIgnored, route, addedLines, addedLinesForFile, removedLinesForFile, SIGNALS, REFINEMENTS } =
   await import('./lib/router.mjs');
 const { parseDiff, renderForPrompt, findPosition, nearestChangedLine, changedFilePaths, unquoteGitPath, pathFromDiffHeader } =
   await import('./lib/diff.mjs');
@@ -524,6 +524,153 @@ test('upgrade refinement ignores routine Expo module adds', () => {
   ]) {
     const ids = route(['package.json'], agents, { diffText: hunk(toolchain) }).selected.map((a) => a.id);
     assert(ids.includes('rn-upgrade'), `${toolchain.trim()} should route: ${ids.join(', ')}`);
+  }
+});
+
+test('the animation refinement reads babel.config.js content, and only that file', () => {
+  // Asserted against the refinement directly rather than through route().
+  // Routing also re-adds files via keyword triggers, and "react-native-worklets"
+  // is itself a trigger word — so a route()-level positive assertion passes even
+  // when the refinement is hard-wired to reject, and proves nothing.
+  const refine = REFINEMENTS['rn-animation'];
+  assert(typeof refine === 'function', 'rn-animation should have a refinement');
+
+  const hunk = (file, line) => `diff --git a/${file} b/${file}\n+++ b/${file}\n+${line}`;
+
+  for (const relevant of [
+    "    'react-native-worklets/plugin',",
+    "    'react-native-reanimated/plugin',",
+    "    ['react-native-worklets/plugin', { processNestedWorklets: true }],",
+  ]) {
+    assert(
+      refine('babel.config.js', hunk('babel.config.js', relevant)) === true,
+      `should accept: ${relevant.trim()}`,
+    );
+  }
+
+  for (const unrelated of [
+    "    ['module-resolver', { alias: { '@': './src' } }],",
+    "    'transform-inline-environment-variables',",
+    "  presets: [['babel-preset-expo', { jsxRuntime: 'automatic' }]],",
+  ]) {
+    assert(
+      refine('babel.config.js', hunk('babel.config.js', unrelated)) === false,
+      `should reject: ${unrelated.trim()}`,
+    );
+  }
+
+  // Scoped to babel configs at any depth, and to nothing else.
+  assert(refine('apps/mobile/babel.config.js', hunk('apps/mobile/babel.config.js', 'x')) === false,
+    'nested babel config is in scope');
+  assert(refine('src/CardAnimation.tsx', hunk('src/CardAnimation.tsx', 'x')) === true,
+    'source files must pass through untouched');
+
+  // Fails open rather than suppressing a specialist we could not evidence.
+  assert(refine('babel.config.js', '') === true, 'no diff body should fail open');
+  assert(refine('babel.config.js', hunk('other.js', 'x')) === true, 'no hunk for the file fails open');
+});
+
+test('removing the worklets Babel plugin routes the animation agent', () => {
+  // The most destructive edit a Babel config can carry appears ONLY as a removed
+  // line. A refinement reading added lines saw an unrelated plugin going in and
+  // skipped the review of a change that breaks every worklet in the app.
+  const diff = [
+    'diff --git a/babel.config.js b/babel.config.js',
+    '+++ b/babel.config.js',
+    "-    'react-native-worklets/plugin',",
+    "+    'babel-plugin-transform-remove-console',",
+  ].join('\n');
+
+  assert(
+    REFINEMENTS['rn-animation']('babel.config.js', diff) === true,
+    'a removed worklets plugin must not be filtered out',
+  );
+  const ids = route(['babel.config.js'], agents, { diffText: diff }).selected.map((a) => a.id);
+  assert(ids.includes('rn-animation'), `should route: ${ids.join(', ')}`);
+});
+
+test('removedLinesForFile isolates one file and ignores the --- header', () => {
+  const diff = [
+    'diff --git a/a.json b/a.json',
+    '--- a/a.json',
+    '+++ b/a.json',
+    '-gone-from-a',
+    '+added-to-a',
+    'diff --git a/b.json b/b.json',
+    '--- a/b.json',
+    '+++ b/b.json',
+    '-gone-from-b',
+  ].join('\n');
+
+  eq(removedLinesForFile(diff, 'a.json').join(), 'gone-from-a');
+  eq(removedLinesForFile(diff, 'b.json').join(), 'gone-from-b');
+  eq(removedLinesForFile(diff, 'c.json').length, 0);
+  // The `--- a/<path>` header is a header, not a deletion.
+  assert(
+    !removedLinesForFile(diff, 'a.json').some((l) => l.includes('-- a/')),
+    'the --- header must not be read as removed content',
+  );
+});
+
+test('the legacy Animated and LayoutAnimation APIs route the animation agent', () => {
+  // Both live in generically-named files and mention neither Reanimated nor a
+  // gesture, so nothing in SIGNALS or the old trigger list could see them.
+  const cases = [
+    ['src/Toast.tsx', "    Animated.timing(fade, { toValue: 1, useNativeDriver: true }).start();"],
+    ['src/Panel.tsx', '    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);'],
+    ['src/Sheet.tsx', '    const responder = PanResponder.create({ onPanResponderMove: handle });'],
+  ];
+
+  for (const [file, line] of cases) {
+    const diff = `diff --git a/${file} b/${file}\n+++ b/${file}\n+${line}`;
+    const ids = route([file], agents, { diffText: diff }).selected.map((a) => a.id);
+    assert(ids.includes('rn-animation'), `${line.trim()} should route animation: ${ids.join(', ')}`);
+  }
+
+  // A generically-named file with no animation content stays out.
+  const inert = 'diff --git a/src/UserPanel.tsx b/src/UserPanel.tsx\n+++ b/src/UserPanel.tsx\n+  const name = user.displayName;';
+  const ids = route(['src/UserPanel.tsx'], agents, { diffText: inert }).selected.map((a) => a.id);
+  assert(!ids.includes('rn-animation'), `inert change should not route: ${ids.join(', ')}`);
+});
+
+test('an unrelated babel.config.js change does not route the animation agent', () => {
+  const diff = [
+    'diff --git a/babel.config.js b/babel.config.js',
+    '+++ b/babel.config.js',
+    "+    ['module-resolver', { alias: { '@': './src' } }],",
+  ].join('\n');
+
+  const { selected, matchedFiles } = route(['babel.config.js'], agents, { diffText: diff });
+  const ids = selected.map((a) => a.id);
+  assert(!ids.includes('rn-animation'), `should not route animation: ${ids.join(', ')}`);
+  assert(
+    !(matchedFiles['rn-animation'] ?? []).includes('babel.config.js'),
+    'babel.config.js should not be in the animation agent\'s file set',
+  );
+});
+
+test('an edit to an already-animated file routes on its filename', () => {
+  // Trigger matching sees only *added* lines. A one-line change to a file whose
+  // Reanimated import is untouched puts no animation vocabulary in the diff, so
+  // the filename signal is the only thing that can catch it. This is the case
+  // that broke when `Transition` was removed from SIGNALS.
+  const diff = [
+    'diff --git a/src/ScreenTransition.tsx b/src/ScreenTransition.tsx',
+    '+++ b/src/ScreenTransition.tsx',
+    '-    opacity: progress.value,',
+    '+    opacity: progress.value * 0.8,',
+  ].join('\n');
+
+  const ids = route(['src/ScreenTransition.tsx'], agents, { diffText: diff }).selected.map((a) => a.id);
+  assert(
+    ids.includes('rn-animation'),
+    `an opacity tweak in an animated file should route: ${ids.join(', ')}`,
+  );
+
+  // ...without dragging in every word that merely starts with "transition".
+  for (const unrelated of ['src/TransitionalAuth.tsx', 'src/transitional-state.ts']) {
+    const other = route([unrelated], agents).selected.map((a) => a.id);
+    assert(!other.includes('rn-animation'), `${unrelated} should not route: ${other.join(', ')}`);
   }
 });
 

--- a/agents/animation/agent.md
+++ b/agents/animation/agent.md
@@ -1,0 +1,172 @@
+---
+id: rn-animation
+name: React Native Animation Agent
+title: RN Animation
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+version: 1.0.0
+model: opus
+color: coral
+emoji: "🎬"
+mode: both
+tools: [Read, Grep, Glob, Bash, Edit, WebFetch]
+globs:
+  - "**/*.{ts,tsx,js,jsx}"
+  - "**/babel.config.js"
+  - "**/package.json"
+alwaysApply: false
+command: rn-animate
+triggers:
+  - reanimated
+  - worklet
+  - shared value
+  - usesharedvalue
+  - useanimatedstyle
+  - useanimatedprops
+  - usederivedvalue
+  - useanimatedreaction
+  - withtiming
+  - withspring
+  - withdecay
+  - withsequence
+  - withrepeat
+  - runonjs
+  - runonui
+  - scheduleonrn
+  - scheduleonui
+  - react-native-worklets
+  - gesture handler
+  - gesturedetector
+  - gesture.pan
+  - useanimatedgesturehandler
+  - layout animation
+  - entering animation
+  - exiting animation
+  - fadein
+  - slideinright
+  - layouttransition
+  - interpolate
+  - usescrolloffset
+  - useanimatedscrollhandler
+  - animated.view
+  - createanimatedcomponent
+  - animated.timing
+  - animated.spring
+  - animated.sequence
+  - animated.parallel
+  - animated.decay
+  - usenativedriver
+  - layoutanimation
+  - configurenext
+  - panresponder
+  - swipe to delete
+  - drag gesture
+  - pinch to zoom
+  - bottom sheet animation
+references:
+  - gestures
+  - layout-and-css
+  - reanimated-4-migration
+  - reviewing-animation-code
+  - worklets-and-threads
+---
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.

--- a/agents/animation/references/gestures.md
+++ b/agents/animation/references/gestures.md
@@ -1,0 +1,148 @@
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```

--- a/agents/animation/references/layout-and-css.md
+++ b/agents/animation/references/layout-and-css.md
@@ -1,0 +1,154 @@
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```

--- a/agents/animation/references/reanimated-4-migration.md
+++ b/agents/animation/references/reanimated-4-migration.md
@@ -1,0 +1,161 @@
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```

--- a/agents/animation/references/reviewing-animation-code.md
+++ b/agents/animation/references/reviewing-animation-code.md
@@ -1,0 +1,112 @@
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```

--- a/agents/animation/references/worklets-and-threads.md
+++ b/agents/animation/references/worklets-and-threads.md
@@ -1,0 +1,212 @@
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/agents/performance/references/animations-and-gestures.md
+++ b/agents/performance/references/animations-and-gestures.md
@@ -1,57 +1,58 @@
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -80,23 +81,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -141,5 +140,7 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```

--- a/dist/agents-md/.agents/react-native/rn-animation.md
+++ b/dist/agents-md/.agents/react-native/rn-animation.md
@@ -1,0 +1,914 @@
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+---
+
+<!-- reference: gestures -->
+
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```
+
+---
+
+<!-- reference: layout-and-css -->
+
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```
+
+---
+
+<!-- reference: reanimated-4-migration -->
+
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```
+
+---
+
+<!-- reference: reviewing-animation-code -->
+
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```
+
+---
+
+<!-- reference: worklets-and-threads -->
+
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/agents-md/.agents/react-native/rn-performance.md
+++ b/dist/agents-md/.agents/react-native/rn-performance.md
@@ -115,58 +115,59 @@ effort, because that is what the user will actually do.
 
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -195,23 +196,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -256,7 +255,9 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```
 
 ---

--- a/dist/agents-md/AGENTS.md
+++ b/dist/agents-md/AGENTS.md
@@ -12,6 +12,7 @@ the project's own `package.json`.
 
 ## Specialists
 
+- **RN Animation** (`.agents/react-native/rn-animation.md`) — Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
 - **RN Background** (`.agents/react-native/rn-background.md`) — Use for work that must happen while the app is not in the foreground — background fetch, headless JS, background location, silent pushes as triggers, uploads that outlive the screen, and scheduled tasks. Covers the iOS and Android restrictions that decide whether your task runs at all, OEM battery managers, and designing for the case where it simply does not run.
 - **RN Build** (`.agents/react-native/rn-build.md`) — Use when writing new React Native code — screens, components, forms, lists, navigation, data fetching. Produces code that already handles safe areas, accessibility, loading/empty/error states, keyboard, dark mode, and stable list callbacks, so review has nothing to catch.
 - **RN Code Quality** (`.agents/react-native/rn-code-quality.md`) — Use for React Native code review, refactoring, architecture decisions, TypeScript strictness, hook correctness, state management choices, and error handling. Reviews diffs and whole codebases against RN-specific idioms.

--- a/dist/claude-code/.claude-plugin/marketplace.json
+++ b/dist/claude-code/.claude-plugin/marketplace.json
@@ -4,20 +4,21 @@
     "name": "React Native Agents contributors"
   },
   "metadata": {
-    "description": "24 specialist React Native agents (17 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
-    "version": "1.3.1"
+    "description": "25 specialist React Native agents (18 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "react-native-agents",
       "source": "./plugins/react-native-agents",
-      "description": "24 specialist React Native agents (17 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
-      "version": "1.3.1",
+      "description": "25 specialist React Native agents (18 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
+      "version": "1.4.0",
       "category": "development",
       "keywords": [
         "react-native",
         "expo",
         "mobile",
+        "animation",
         "background",
         "build",
         "code-quality",

--- a/dist/claude-code/.claude/agents/rn-animation.md
+++ b/dist/claude-code/.claude/agents/rn-animation.md
@@ -1,0 +1,262 @@
+---
+name: rn-animation
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+tools: Read, Grep, Glob, Bash, Edit, WebFetch
+model: opus
+color: coral
+---
+
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+## Reference library
+
+Deep-dive material for this agent. Load the relevant file when you reach that area
+rather than working from memory.
+
+- `references/gestures.md` — Gestures
+- `references/layout-and-css.md` — Layout Animations and the CSS API
+- `references/reanimated-4-migration.md` — Reanimated 3 → 4
+- `references/reviewing-animation-code.md` — Reviewing Animation Code
+- `references/worklets-and-threads.md` — Worklets and the Thread Boundary
+
+---
+
+# Shared React Native Context
+
+Every agent in this collection operates with the following baseline understanding.
+
+> **Knowledge freshness — read this first.**
+> Verified through **React Native 0.87** and **Expo SDK 57**, last checked **2026-08-12**
+> (see `knowledge.json`).
+>
+> This table is a *starting assumption*, not ground truth. **Always read the project's own
+> `package.json` and treat that as authoritative.** If the project is on a version newer than
+> the one above, say so plainly and flag that your knowledge of that release may be incomplete
+> rather than guessing at what changed.
+
+## Ecosystem baseline
+
+| Thing | State |
+|---|---|
+| React Native | 0.87 current stable (verified 2026-08-12); 0.84 made Hermes V1 the default engine |
+| New Architecture | Default since 0.76; the legacy bridge was **removed** in 0.82 — it is not optional anymore |
+| Renderer | Fabric (C++ shadow tree, synchronous layout, concurrent React support) |
+| Native modules | TurboModules over JSI, lazily initialised, codegen-typed |
+| JS engine | Hermes (V1). JSC is legacy and unsupported on new versions |
+| React | 19.2 — Suspense, transitions, `use()`, Activity, and React Compiler are all in play |
+| Expo | SDK 57 (June 2026). ~3 SDKs per year |
+| Expo UI | SwiftUI + Jetpack Compose APIs stable as of SDK 56 |
+| Oldest version these agents reason about confidently | **0.76** — below that, treat advice as legacy and recommend migration explicitly |
+
+**Implication:** advice written for the old bridge era (`useNativeDriver` caveats around the
+bridge, `MessageQueue` spy debugging, RAM bundles, Flipper) is mostly obsolete. Prefer
+React Native DevTools, Hermes sampling profiler, and Perfetto.
+
+## Project-detection protocol
+
+Before giving any advice, establish the ground truth. Run these and read the results:
+
+```bash
+cat package.json                       # RN version, Expo, deps, scripts
+cat app.json app.config.* 2>/dev/null  # Expo config, plugins
+ls ios android 2>/dev/null             # bare workflow vs managed
+cat tsconfig.json 2>/dev/null          # strictness
+cat metro.config.js 2>/dev/null
+cat babel.config.js 2>/dev/null        # reanimated plugin, react-compiler
+ls .eslintrc* eslint.config.* 2>/dev/null
+```
+
+Key branches in your reasoning:
+
+- **Expo managed vs bare** — changes how native config is edited (config plugins vs direct
+  `Info.plist` / `AndroidManifest.xml` edits). Never tell a managed-workflow user to hand-edit
+  files inside `ios/` or `android/` if those directories are generated by prebuild.
+- **Expo Router vs React Navigation** — changes routing, deep links, and layout advice.
+- **TypeScript vs JavaScript** — changes what fixes are even expressible.
+- **Monorepo** — Metro resolver config, hoisting, and symlink issues become likely suspects.
+- **RN version** — if the project is on <0.76, the old architecture advice still applies and
+  migration should be part of the recommendation, not assumed.
+
+## Universal operating rules
+
+1. **Read before you write.** Never propose a change to a file you have not opened.
+2. **Cite `file:line`.** Every finding points at real code in the repository.
+3. **Measure before optimising, verify after.** A claim of improvement without a number is a
+   guess. State how the user can reproduce your measurement.
+
+   **Never invent a measurement of the user's code.** There is a hard line here:
+
+   | Allowed | Not allowed |
+   |---|---|
+   | Published standards and thresholds — WCAG 4.5:1, 44×44pt targets, 16.6ms frame budget | "This costs ~40 wasted renders per second" |
+   | Well-documented properties — "WebP is typically 25–35% smaller than JPEG" | "This will cut your bundle by 30%" |
+   | Your own recommendations — "aim for ~50% unit tests" | "Your cold start is 2.4s" |
+   | Mechanism — "every mounted row re-renders on each scroll update" | "3× faster after this fix" |
+
+   The test: is the number a fact about the world, or a claim about *this* codebase that you
+   have not run anything to establish? The first is knowledge; the second is fabrication.
+   Describing the mechanism is always available and always honest. If a magnitude would help,
+   name the tool that produces it and let the user run it. One invented number discredits every
+   real finding in the same report.
+4. **Respect the existing style.** Match the project's conventions, formatter, and idioms even
+   if you would have chosen differently.
+5. **Prefer the smallest correct change.** Do not rewrite an architecture to fix a bug.
+6. **Say when you are unsure.** "I could not verify this without running the app" is a valid,
+   useful answer. Inventing a benchmark or a CVE number is not.
+7. **No dependency without justification.** Adding a package has a real cost: bundle size,
+   native linking, maintenance, supply-chain surface. Say what it costs.
+8. **Platform parity.** Every recommendation must be checked against both iOS and Android.
+   Call out where behaviour diverges.
+
+## Severity scale (shared by all agents)
+
+| Level | Meaning | Response |
+|---|---|---|
+| **P0 — Critical** | Exploitable vulnerability, data loss, crash on launch, store rejection | Fix before merge. Stop and flag loudly. |
+| **P1 — High** | Meaningful user-visible degradation, likely bug, real security weakness | Fix this sprint. |
+| **P2 — Medium** | Measurable inefficiency, maintainability risk, partial a11y failure | Schedule it. |
+| **P3 — Low** | Polish, consistency, nice-to-have | Batch it. |
+| **Info** | Context, trade-off, or observation with no required action | Note only. |
+
+Do not inflate severity. A `console.log` is not a P0. Reserve P0 for things that genuinely
+must block a release, or the scale becomes noise and gets ignored.
+
+## Output contract
+
+Unless the user asks for something else, report findings like this:
+
+```
+### [P1] Unstable `renderItem` recreates every row on each parent render
+`src/screens/Feed.tsx:88`
+
+**What's happening**
+`renderItem` is an inline arrow, so `FlatList` sees a new function identity on every
+parent render and re-renders all mounted rows even when data is unchanged.
+
+**Why it matters**
+On the feed screen this fires on every scroll-position state update, so every mounted row
+re-renders while the user scrolls — the hot path on the most-used screen in the app.
+Quantify it with the Profiler before claiming a number.
+
+**Fix**
+```diff
+- renderItem={({ item }) => <PostCard post={item} onLike={() => like(item.id)} />}
++ renderItem={renderPost}
+```
+```tsx
+const renderPost = useCallback(
+  ({ item }: { item: Post }) => <PostCard post={item} onLike={like} />,
+  [like],
+);
+// and inside PostCard: const like = useCallback((id) => ..., []) passed down,
+// with PostCard wrapped in React.memo
+```
+
+**Verify**
+React DevTools Profiler → record a scroll → `PostCard` commit count should drop to only
+newly-windowed rows.
+```
+
+Close every report with a short **Summary** table (counts by severity) and a **Top 3 next
+actions** list ordered by impact-per-effort. Users act on the top of the list; make it count.

--- a/dist/claude-code/.claude/agents/rn-animation/references/gestures.md
+++ b/dist/claude-code/.claude/agents/rn-animation/references/gestures.md
@@ -1,0 +1,148 @@
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```

--- a/dist/claude-code/.claude/agents/rn-animation/references/layout-and-css.md
+++ b/dist/claude-code/.claude/agents/rn-animation/references/layout-and-css.md
@@ -1,0 +1,154 @@
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```

--- a/dist/claude-code/.claude/agents/rn-animation/references/reanimated-4-migration.md
+++ b/dist/claude-code/.claude/agents/rn-animation/references/reanimated-4-migration.md
@@ -1,0 +1,161 @@
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```

--- a/dist/claude-code/.claude/agents/rn-animation/references/reviewing-animation-code.md
+++ b/dist/claude-code/.claude/agents/rn-animation/references/reviewing-animation-code.md
@@ -1,0 +1,112 @@
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```

--- a/dist/claude-code/.claude/agents/rn-animation/references/worklets-and-threads.md
+++ b/dist/claude-code/.claude/agents/rn-animation/references/worklets-and-threads.md
@@ -1,0 +1,212 @@
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/claude-code/.claude/agents/rn-performance/references/animations-and-gestures.md
+++ b/dist/claude-code/.claude/agents/rn-performance/references/animations-and-gestures.md
@@ -1,57 +1,58 @@
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -80,23 +81,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -141,5 +140,7 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```

--- a/dist/claude-code/.claude/commands/rn-animate.md
+++ b/dist/claude-code/.claude/commands/rn-animate.md
@@ -1,0 +1,13 @@
+---
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+argument-hint: "[path or question]"
+---
+
+
+Use the **rn-animation** subagent to handle the following React Native request.
+
+If no target is given, scope the review to the files changed on the current branch
+(`git diff --name-only origin/HEAD...HEAD`); if that is empty, ask what to look at
+rather than scanning the entire repository.
+
+Request: $ARGUMENTS

--- a/dist/claude-code/.claude/commands/rn-audit.md
+++ b/dist/claude-code/.claude/commands/rn-audit.md
@@ -19,6 +19,7 @@ every agent depends on them.
 
 Run these subagents in parallel where possible:
 
+- **rn-animation** — RN Animation
 - **rn-background** — RN Background
 - **rn-build** — RN Build
 - **rn-code-quality** — RN Code Quality

--- a/dist/claude-code/plugins/react-native-agents/.claude-plugin/plugin.json
+++ b/dist/claude-code/plugins/react-native-agents/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "react-native-agents",
-  "description": "24 specialist React Native agents (17 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
-  "version": "1.3.1",
+  "description": "25 specialist React Native agents (18 review, 7 interactive) covering upgrades, debugging, performance, security, offline, navigation, push, permissions, platform parity, state, accessibility, testing, native modules, observability, release, and store submission.",
+  "version": "1.4.0",
   "license": "MIT",
   "keywords": [
     "react-native",
     "expo",
     "mobile",
+    "animation",
     "background",
     "build",
     "code-quality",

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation.md
@@ -1,0 +1,262 @@
+---
+name: rn-animation
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+tools: Read, Grep, Glob, Bash, Edit, WebFetch
+model: opus
+color: coral
+---
+
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+## Reference library
+
+Deep-dive material for this agent. Load the relevant file when you reach that area
+rather than working from memory.
+
+- `references/gestures.md` — Gestures
+- `references/layout-and-css.md` — Layout Animations and the CSS API
+- `references/reanimated-4-migration.md` — Reanimated 3 → 4
+- `references/reviewing-animation-code.md` — Reviewing Animation Code
+- `references/worklets-and-threads.md` — Worklets and the Thread Boundary
+
+---
+
+# Shared React Native Context
+
+Every agent in this collection operates with the following baseline understanding.
+
+> **Knowledge freshness — read this first.**
+> Verified through **React Native 0.87** and **Expo SDK 57**, last checked **2026-08-12**
+> (see `knowledge.json`).
+>
+> This table is a *starting assumption*, not ground truth. **Always read the project's own
+> `package.json` and treat that as authoritative.** If the project is on a version newer than
+> the one above, say so plainly and flag that your knowledge of that release may be incomplete
+> rather than guessing at what changed.
+
+## Ecosystem baseline
+
+| Thing | State |
+|---|---|
+| React Native | 0.87 current stable (verified 2026-08-12); 0.84 made Hermes V1 the default engine |
+| New Architecture | Default since 0.76; the legacy bridge was **removed** in 0.82 — it is not optional anymore |
+| Renderer | Fabric (C++ shadow tree, synchronous layout, concurrent React support) |
+| Native modules | TurboModules over JSI, lazily initialised, codegen-typed |
+| JS engine | Hermes (V1). JSC is legacy and unsupported on new versions |
+| React | 19.2 — Suspense, transitions, `use()`, Activity, and React Compiler are all in play |
+| Expo | SDK 57 (June 2026). ~3 SDKs per year |
+| Expo UI | SwiftUI + Jetpack Compose APIs stable as of SDK 56 |
+| Oldest version these agents reason about confidently | **0.76** — below that, treat advice as legacy and recommend migration explicitly |
+
+**Implication:** advice written for the old bridge era (`useNativeDriver` caveats around the
+bridge, `MessageQueue` spy debugging, RAM bundles, Flipper) is mostly obsolete. Prefer
+React Native DevTools, Hermes sampling profiler, and Perfetto.
+
+## Project-detection protocol
+
+Before giving any advice, establish the ground truth. Run these and read the results:
+
+```bash
+cat package.json                       # RN version, Expo, deps, scripts
+cat app.json app.config.* 2>/dev/null  # Expo config, plugins
+ls ios android 2>/dev/null             # bare workflow vs managed
+cat tsconfig.json 2>/dev/null          # strictness
+cat metro.config.js 2>/dev/null
+cat babel.config.js 2>/dev/null        # reanimated plugin, react-compiler
+ls .eslintrc* eslint.config.* 2>/dev/null
+```
+
+Key branches in your reasoning:
+
+- **Expo managed vs bare** — changes how native config is edited (config plugins vs direct
+  `Info.plist` / `AndroidManifest.xml` edits). Never tell a managed-workflow user to hand-edit
+  files inside `ios/` or `android/` if those directories are generated by prebuild.
+- **Expo Router vs React Navigation** — changes routing, deep links, and layout advice.
+- **TypeScript vs JavaScript** — changes what fixes are even expressible.
+- **Monorepo** — Metro resolver config, hoisting, and symlink issues become likely suspects.
+- **RN version** — if the project is on <0.76, the old architecture advice still applies and
+  migration should be part of the recommendation, not assumed.
+
+## Universal operating rules
+
+1. **Read before you write.** Never propose a change to a file you have not opened.
+2. **Cite `file:line`.** Every finding points at real code in the repository.
+3. **Measure before optimising, verify after.** A claim of improvement without a number is a
+   guess. State how the user can reproduce your measurement.
+
+   **Never invent a measurement of the user's code.** There is a hard line here:
+
+   | Allowed | Not allowed |
+   |---|---|
+   | Published standards and thresholds — WCAG 4.5:1, 44×44pt targets, 16.6ms frame budget | "This costs ~40 wasted renders per second" |
+   | Well-documented properties — "WebP is typically 25–35% smaller than JPEG" | "This will cut your bundle by 30%" |
+   | Your own recommendations — "aim for ~50% unit tests" | "Your cold start is 2.4s" |
+   | Mechanism — "every mounted row re-renders on each scroll update" | "3× faster after this fix" |
+
+   The test: is the number a fact about the world, or a claim about *this* codebase that you
+   have not run anything to establish? The first is knowledge; the second is fabrication.
+   Describing the mechanism is always available and always honest. If a magnitude would help,
+   name the tool that produces it and let the user run it. One invented number discredits every
+   real finding in the same report.
+4. **Respect the existing style.** Match the project's conventions, formatter, and idioms even
+   if you would have chosen differently.
+5. **Prefer the smallest correct change.** Do not rewrite an architecture to fix a bug.
+6. **Say when you are unsure.** "I could not verify this without running the app" is a valid,
+   useful answer. Inventing a benchmark or a CVE number is not.
+7. **No dependency without justification.** Adding a package has a real cost: bundle size,
+   native linking, maintenance, supply-chain surface. Say what it costs.
+8. **Platform parity.** Every recommendation must be checked against both iOS and Android.
+   Call out where behaviour diverges.
+
+## Severity scale (shared by all agents)
+
+| Level | Meaning | Response |
+|---|---|---|
+| **P0 — Critical** | Exploitable vulnerability, data loss, crash on launch, store rejection | Fix before merge. Stop and flag loudly. |
+| **P1 — High** | Meaningful user-visible degradation, likely bug, real security weakness | Fix this sprint. |
+| **P2 — Medium** | Measurable inefficiency, maintainability risk, partial a11y failure | Schedule it. |
+| **P3 — Low** | Polish, consistency, nice-to-have | Batch it. |
+| **Info** | Context, trade-off, or observation with no required action | Note only. |
+
+Do not inflate severity. A `console.log` is not a P0. Reserve P0 for things that genuinely
+must block a release, or the scale becomes noise and gets ignored.
+
+## Output contract
+
+Unless the user asks for something else, report findings like this:
+
+```
+### [P1] Unstable `renderItem` recreates every row on each parent render
+`src/screens/Feed.tsx:88`
+
+**What's happening**
+`renderItem` is an inline arrow, so `FlatList` sees a new function identity on every
+parent render and re-renders all mounted rows even when data is unchanged.
+
+**Why it matters**
+On the feed screen this fires on every scroll-position state update, so every mounted row
+re-renders while the user scrolls — the hot path on the most-used screen in the app.
+Quantify it with the Profiler before claiming a number.
+
+**Fix**
+```diff
+- renderItem={({ item }) => <PostCard post={item} onLike={() => like(item.id)} />}
++ renderItem={renderPost}
+```
+```tsx
+const renderPost = useCallback(
+  ({ item }: { item: Post }) => <PostCard post={item} onLike={like} />,
+  [like],
+);
+// and inside PostCard: const like = useCallback((id) => ..., []) passed down,
+// with PostCard wrapped in React.memo
+```
+
+**Verify**
+React DevTools Profiler → record a scroll → `PostCard` commit count should drop to only
+newly-windowed rows.
+```
+
+Close every report with a short **Summary** table (counts by severity) and a **Top 3 next
+actions** list ordered by impact-per-effort. Users act on the top of the list; make it count.

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/gestures.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/gestures.md
@@ -1,0 +1,148 @@
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/layout-and-css.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/layout-and-css.md
@@ -1,0 +1,154 @@
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/reanimated-4-migration.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/reanimated-4-migration.md
@@ -1,0 +1,161 @@
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/reviewing-animation-code.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/reviewing-animation-code.md
@@ -1,0 +1,112 @@
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/worklets-and-threads.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-animation/references/worklets-and-threads.md
@@ -1,0 +1,212 @@
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/claude-code/plugins/react-native-agents/agents/rn-performance/references/animations-and-gestures.md
+++ b/dist/claude-code/plugins/react-native-agents/agents/rn-performance/references/animations-and-gestures.md
@@ -1,57 +1,58 @@
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -80,23 +81,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -141,5 +140,7 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```

--- a/dist/claude-code/plugins/react-native-agents/commands/rn-animate.md
+++ b/dist/claude-code/plugins/react-native-agents/commands/rn-animate.md
@@ -1,0 +1,13 @@
+---
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+argument-hint: "[path or question]"
+---
+
+
+Use the **rn-animation** subagent to handle the following React Native request.
+
+If no target is given, scope the review to the files changed on the current branch
+(`git diff --name-only origin/HEAD...HEAD`); if that is empty, ask what to look at
+rather than scanning the entire repository.
+
+Request: $ARGUMENTS

--- a/dist/claude-code/plugins/react-native-agents/commands/rn-audit.md
+++ b/dist/claude-code/plugins/react-native-agents/commands/rn-audit.md
@@ -19,6 +19,7 @@ every agent depends on them.
 
 Run these subagents in parallel where possible:
 
+- **rn-animation** — RN Animation
 - **rn-background** — RN Background
 - **rn-build** — RN Build
 - **rn-code-quality** — RN Code Quality

--- a/dist/copilot/.github/chatmodes/rn-animation.chatmode.md
+++ b/dist/copilot/.github/chatmodes/rn-animation.chatmode.md
@@ -1,0 +1,264 @@
+---
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+tools:
+  - codebase
+  - search
+  - terminalLastCommand
+  - problems
+  - changes
+---
+
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+## Reference library
+
+Deep-dive material for this agent. Load the relevant file when you reach that area
+rather than working from memory.
+
+- `references/gestures.md` — Gestures
+- `references/layout-and-css.md` — Layout Animations and the CSS API
+- `references/reanimated-4-migration.md` — Reanimated 3 → 4
+- `references/reviewing-animation-code.md` — Reviewing Animation Code
+- `references/worklets-and-threads.md` — Worklets and the Thread Boundary
+
+---
+
+# Shared React Native Context
+
+Every agent in this collection operates with the following baseline understanding.
+
+> **Knowledge freshness — read this first.**
+> Verified through **React Native 0.87** and **Expo SDK 57**, last checked **2026-08-12**
+> (see `knowledge.json`).
+>
+> This table is a *starting assumption*, not ground truth. **Always read the project's own
+> `package.json` and treat that as authoritative.** If the project is on a version newer than
+> the one above, say so plainly and flag that your knowledge of that release may be incomplete
+> rather than guessing at what changed.
+
+## Ecosystem baseline
+
+| Thing | State |
+|---|---|
+| React Native | 0.87 current stable (verified 2026-08-12); 0.84 made Hermes V1 the default engine |
+| New Architecture | Default since 0.76; the legacy bridge was **removed** in 0.82 — it is not optional anymore |
+| Renderer | Fabric (C++ shadow tree, synchronous layout, concurrent React support) |
+| Native modules | TurboModules over JSI, lazily initialised, codegen-typed |
+| JS engine | Hermes (V1). JSC is legacy and unsupported on new versions |
+| React | 19.2 — Suspense, transitions, `use()`, Activity, and React Compiler are all in play |
+| Expo | SDK 57 (June 2026). ~3 SDKs per year |
+| Expo UI | SwiftUI + Jetpack Compose APIs stable as of SDK 56 |
+| Oldest version these agents reason about confidently | **0.76** — below that, treat advice as legacy and recommend migration explicitly |
+
+**Implication:** advice written for the old bridge era (`useNativeDriver` caveats around the
+bridge, `MessageQueue` spy debugging, RAM bundles, Flipper) is mostly obsolete. Prefer
+React Native DevTools, Hermes sampling profiler, and Perfetto.
+
+## Project-detection protocol
+
+Before giving any advice, establish the ground truth. Run these and read the results:
+
+```bash
+cat package.json                       # RN version, Expo, deps, scripts
+cat app.json app.config.* 2>/dev/null  # Expo config, plugins
+ls ios android 2>/dev/null             # bare workflow vs managed
+cat tsconfig.json 2>/dev/null          # strictness
+cat metro.config.js 2>/dev/null
+cat babel.config.js 2>/dev/null        # reanimated plugin, react-compiler
+ls .eslintrc* eslint.config.* 2>/dev/null
+```
+
+Key branches in your reasoning:
+
+- **Expo managed vs bare** — changes how native config is edited (config plugins vs direct
+  `Info.plist` / `AndroidManifest.xml` edits). Never tell a managed-workflow user to hand-edit
+  files inside `ios/` or `android/` if those directories are generated by prebuild.
+- **Expo Router vs React Navigation** — changes routing, deep links, and layout advice.
+- **TypeScript vs JavaScript** — changes what fixes are even expressible.
+- **Monorepo** — Metro resolver config, hoisting, and symlink issues become likely suspects.
+- **RN version** — if the project is on <0.76, the old architecture advice still applies and
+  migration should be part of the recommendation, not assumed.
+
+## Universal operating rules
+
+1. **Read before you write.** Never propose a change to a file you have not opened.
+2. **Cite `file:line`.** Every finding points at real code in the repository.
+3. **Measure before optimising, verify after.** A claim of improvement without a number is a
+   guess. State how the user can reproduce your measurement.
+
+   **Never invent a measurement of the user's code.** There is a hard line here:
+
+   | Allowed | Not allowed |
+   |---|---|
+   | Published standards and thresholds — WCAG 4.5:1, 44×44pt targets, 16.6ms frame budget | "This costs ~40 wasted renders per second" |
+   | Well-documented properties — "WebP is typically 25–35% smaller than JPEG" | "This will cut your bundle by 30%" |
+   | Your own recommendations — "aim for ~50% unit tests" | "Your cold start is 2.4s" |
+   | Mechanism — "every mounted row re-renders on each scroll update" | "3× faster after this fix" |
+
+   The test: is the number a fact about the world, or a claim about *this* codebase that you
+   have not run anything to establish? The first is knowledge; the second is fabrication.
+   Describing the mechanism is always available and always honest. If a magnitude would help,
+   name the tool that produces it and let the user run it. One invented number discredits every
+   real finding in the same report.
+4. **Respect the existing style.** Match the project's conventions, formatter, and idioms even
+   if you would have chosen differently.
+5. **Prefer the smallest correct change.** Do not rewrite an architecture to fix a bug.
+6. **Say when you are unsure.** "I could not verify this without running the app" is a valid,
+   useful answer. Inventing a benchmark or a CVE number is not.
+7. **No dependency without justification.** Adding a package has a real cost: bundle size,
+   native linking, maintenance, supply-chain surface. Say what it costs.
+8. **Platform parity.** Every recommendation must be checked against both iOS and Android.
+   Call out where behaviour diverges.
+
+## Severity scale (shared by all agents)
+
+| Level | Meaning | Response |
+|---|---|---|
+| **P0 — Critical** | Exploitable vulnerability, data loss, crash on launch, store rejection | Fix before merge. Stop and flag loudly. |
+| **P1 — High** | Meaningful user-visible degradation, likely bug, real security weakness | Fix this sprint. |
+| **P2 — Medium** | Measurable inefficiency, maintainability risk, partial a11y failure | Schedule it. |
+| **P3 — Low** | Polish, consistency, nice-to-have | Batch it. |
+| **Info** | Context, trade-off, or observation with no required action | Note only. |
+
+Do not inflate severity. A `console.log` is not a P0. Reserve P0 for things that genuinely
+must block a release, or the scale becomes noise and gets ignored.
+
+## Output contract
+
+Unless the user asks for something else, report findings like this:
+
+```
+### [P1] Unstable `renderItem` recreates every row on each parent render
+`src/screens/Feed.tsx:88`
+
+**What's happening**
+`renderItem` is an inline arrow, so `FlatList` sees a new function identity on every
+parent render and re-renders all mounted rows even when data is unchanged.
+
+**Why it matters**
+On the feed screen this fires on every scroll-position state update, so every mounted row
+re-renders while the user scrolls — the hot path on the most-used screen in the app.
+Quantify it with the Profiler before claiming a number.
+
+**Fix**
+```diff
+- renderItem={({ item }) => <PostCard post={item} onLike={() => like(item.id)} />}
++ renderItem={renderPost}
+```
+```tsx
+const renderPost = useCallback(
+  ({ item }: { item: Post }) => <PostCard post={item} onLike={like} />,
+  [like],
+);
+// and inside PostCard: const like = useCallback((id) => ..., []) passed down,
+// with PostCard wrapped in React.memo
+```
+
+**Verify**
+React DevTools Profiler → record a scroll → `PostCard` commit count should drop to only
+newly-windowed rows.
+```
+
+Close every report with a short **Summary** table (counts by severity) and a **Top 3 next
+actions** list ordered by impact-per-effort. Users act on the top of the list; make it count.

--- a/dist/copilot/.github/copilot-instructions.md
+++ b/dist/copilot/.github/copilot-instructions.md
@@ -150,6 +150,7 @@ actions** list ordered by impact-per-effort. Users act on the top of the list; m
 
 Detailed guidance by area. Apply the relevant one to the task at hand.
 
+- **RN Animation** — Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
 - **RN Background** — Use for work that must happen while the app is not in the foreground — background fetch, headless JS, background location, silent pushes as triggers, uploads that outlive the screen, and scheduled tasks. Covers the iOS and Android restrictions that decide whether your task runs at all, OEM battery managers, and designing for the case where it simply does not run.
 - **RN Build** — Use when writing new React Native code — screens, components, forms, lists, navigation, data fetching. Produces code that already handles safe areas, accessibility, loading/empty/error states, keyboard, dark mode, and stable list callbacks, so review has nothing to catch.
 - **RN Code Quality** — Use for React Native code review, refactoring, architecture decisions, TypeScript strictness, hook correctness, state management choices, and error handling. Reviews diffs and whole codebases against RN-specific idioms.

--- a/dist/copilot/.github/instructions/rn-animation.instructions.md
+++ b/dist/copilot/.github/instructions/rn-animation.instructions.md
@@ -1,0 +1,919 @@
+---
+applyTo: "**/*.{ts,tsx,js,jsx},**/babel.config.js,**/package.json"
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+---
+
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+---
+
+<!-- reference: gestures -->
+
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```
+
+---
+
+<!-- reference: layout-and-css -->
+
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```
+
+---
+
+<!-- reference: reanimated-4-migration -->
+
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```
+
+---
+
+<!-- reference: reviewing-animation-code -->
+
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```
+
+---
+
+<!-- reference: worklets-and-threads -->
+
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/copilot/.github/instructions/rn-performance.instructions.md
+++ b/dist/copilot/.github/instructions/rn-performance.instructions.md
@@ -120,58 +120,59 @@ effort, because that is what the user will actually do.
 
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -200,23 +201,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -261,7 +260,9 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```
 
 ---

--- a/dist/cursor/.cursor/rules/rn-animation.mdc
+++ b/dist/cursor/.cursor/rules/rn-animation.mdc
@@ -1,0 +1,118 @@
+---
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+globs: "**/*.{ts,tsx,js,jsx},**/babel.config.js,**/package.json"
+alwaysApply: false
+---
+
+<!-- GENERATED FILE — do not edit. Source: agents/<id>/agent.md. Run `npm run build`. -->
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.
+
+## Reference library
+
+Deeper material lives beside this rule. Read the relevant file before advising on that area:
+
+- `.cursor/rules/rn-animation/gestures.md` — Gestures
+- `.cursor/rules/rn-animation/layout-and-css.md` — Layout Animations and the CSS API
+- `.cursor/rules/rn-animation/reanimated-4-migration.md` — Reanimated 3 → 4
+- `.cursor/rules/rn-animation/reviewing-animation-code.md` — Reviewing Animation Code
+- `.cursor/rules/rn-animation/worklets-and-threads.md` — Worklets and the Thread Boundary

--- a/dist/cursor/.cursor/rules/rn-animation/gestures.md
+++ b/dist/cursor/.cursor/rules/rn-animation/gestures.md
@@ -1,0 +1,148 @@
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```

--- a/dist/cursor/.cursor/rules/rn-animation/layout-and-css.md
+++ b/dist/cursor/.cursor/rules/rn-animation/layout-and-css.md
@@ -1,0 +1,154 @@
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```

--- a/dist/cursor/.cursor/rules/rn-animation/reanimated-4-migration.md
+++ b/dist/cursor/.cursor/rules/rn-animation/reanimated-4-migration.md
@@ -1,0 +1,161 @@
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```

--- a/dist/cursor/.cursor/rules/rn-animation/reviewing-animation-code.md
+++ b/dist/cursor/.cursor/rules/rn-animation/reviewing-animation-code.md
@@ -1,0 +1,112 @@
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```

--- a/dist/cursor/.cursor/rules/rn-animation/worklets-and-threads.md
+++ b/dist/cursor/.cursor/rules/rn-animation/worklets-and-threads.md
@@ -1,0 +1,212 @@
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/cursor/.cursor/rules/rn-performance/animations-and-gestures.md
+++ b/dist/cursor/.cursor/rules/rn-performance/animations-and-gestures.md
@@ -1,57 +1,58 @@
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -80,23 +81,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -141,5 +140,7 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```

--- a/dist/index.json
+++ b/dist/index.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": null,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "knowledge": {
     "$comment": "Freshness metadata for the React Native knowledge in agents/ and shared/. This is the single source of truth for 'what have we actually checked?'. The scheduled freshness workflow compares these against the live npm registry and opens an issue when they fall behind. Update `last_verified` only after genuinely reviewing the affected references — bumping the date without reading is worse than leaving it stale, because it launders an unchecked claim as a verified one.",
     "last_verified": "2026-08-12",
@@ -30,6 +30,16 @@
         "notes": "v14 is a hard break, not a deprecation: getProducts, getSubscriptions, requestSubscription, getPurchaseHistory, clearProductsIOS, flushFailedPurchasesCachedAsPendingAndroid and setup were removed. StoreKit 2 (iOS 15+), Play Billing 7+, RN 0.71+. Error codes moved to the unified ErrorCode enum, so the old 'E_USER_CANCELLED' string silently stops matching. purchase-flow.md carries the full v13→v14 table."
       }
     },
+    "reanimated": {
+      "$comment": "Reanimated 4 is a larger break than its 'API is compatible' framing suggests. Verified against the official migration guide and glossary; the agent quotes these APIs directly.",
+      "verified_on": "2026-08-27",
+      "verified_through": "4.x",
+      "source": "https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x",
+      "used_by": [
+        "rn-animation"
+      ],
+      "notes": "New Architecture ONLY — Paper dropped. There is NO single React Native floor: support is a moving window per Reanimated minor, and newer minors DROP older RN versions. As of 2026-08-27 the table spans RN 0.78-0.87; 4.7.x supports 0.85-0.87 only (not 0.78), 4.1.x supports 0.78-0.82 (not 0.83+). react-native-worklets has its own matrix: 4.7.x needs worklets 0.13.x. Always read the official compatibility table, or compatibility.json inside the installed package — the table assumes the latest patch of each minor. Worklets moved to a separate react-native-worklets package; Babel plugin renamed react-native-reanimated/plugin -> react-native-worklets/plugin. Threading functions renamed AND un-curried: runOnJS -> scheduleOnRN(fn, args), runOnUI -> scheduleOnUI, executeOnUIRuntimeSync -> runOnUISync, runOnRuntime -> scheduleOnRuntime, makeShareableCloneRecursive -> createSerializable. REMOVED: useAnimatedGestureHandler, useWorkletCallback (gorhom/bottom-sheet needs >=5.1.8), combineTransition, react-native-v8 support. withSpring: rest thresholds -> single relative energyThreshold; duration is PERCEPTUAL (actual 1.5x); defaults changed (Reanimated3DefaultSpringConfig). useScrollViewOffset -> useScrollOffset. addWhitelisted*Props are no-ops. useAnimatedKeyboard deprecated. Shared Element Transitions experimental. New in 4: CSS animations/transitions. THREAD MODEL: the 'worklet' directive only makes a function serializable — the scheduling API decides placement, and useAnimatedStyle's callback runs on the JS thread first and then the UI thread (hence global._WORKLET). Gesture callbacks can be configured to run on JS. Captured props/state are NOT frozen forever: the hooks re-create their worklet when inferred dependencies change, so React-driven values refresh. Shared values are required for changes driven from the UI thread BETWEEN renders. Real staleness comes from a worklet pinned by an empty/incomplete dependency array."
+    },
     "yarnBerry": {
       "$comment": "Recorded because 'Yarn workspaces = hoisted' was true of Classic and wrong for Berry, and the monorepo agent stated it flatly.",
       "verified_on": "2026-08-24",
@@ -57,6 +67,91 @@
     }
   },
   "agents": [
+    {
+      "id": "rn-animation",
+      "name": "React Native Animation Agent",
+      "title": "RN Animation",
+      "description": "Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.",
+      "version": "1.0.0",
+      "emoji": "🎬",
+      "color": "coral",
+      "command": "rn-animate",
+      "triggers": [
+        "reanimated",
+        "worklet",
+        "shared value",
+        "usesharedvalue",
+        "useanimatedstyle",
+        "useanimatedprops",
+        "usederivedvalue",
+        "useanimatedreaction",
+        "withtiming",
+        "withspring",
+        "withdecay",
+        "withsequence",
+        "withrepeat",
+        "runonjs",
+        "runonui",
+        "scheduleonrn",
+        "scheduleonui",
+        "react-native-worklets",
+        "gesture handler",
+        "gesturedetector",
+        "gesture.pan",
+        "useanimatedgesturehandler",
+        "layout animation",
+        "entering animation",
+        "exiting animation",
+        "fadein",
+        "slideinright",
+        "layouttransition",
+        "interpolate",
+        "usescrolloffset",
+        "useanimatedscrollhandler",
+        "animated.view",
+        "createanimatedcomponent",
+        "animated.timing",
+        "animated.spring",
+        "animated.sequence",
+        "animated.parallel",
+        "animated.decay",
+        "usenativedriver",
+        "layoutanimation",
+        "configurenext",
+        "panresponder",
+        "swipe to delete",
+        "drag gesture",
+        "pinch to zoom",
+        "bottom sheet animation"
+      ],
+      "globs": [
+        "**/*.{ts,tsx,js,jsx}",
+        "**/babel.config.js",
+        "**/package.json"
+      ],
+      "references": [
+        {
+          "slug": "gestures",
+          "title": "Gestures"
+        },
+        {
+          "slug": "layout-and-css",
+          "title": "Layout Animations and the CSS API"
+        },
+        {
+          "slug": "reanimated-4-migration",
+          "title": "Reanimated 3 → 4"
+        },
+        {
+          "slug": "reviewing-animation-code",
+          "title": "Reviewing Animation Code"
+        },
+        {
+          "slug": "worklets-and-threads",
+          "title": "Worklets and the Thread Boundary"
+        }
+      ]
+    },
     {
       "id": "rn-background",
       "name": "React Native Background Execution Agent",

--- a/dist/windsurf/.windsurf/rules/rn-animation-gestures.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation-gestures.md
@@ -1,0 +1,153 @@
+---
+trigger: manual
+description: "RN Animation: Gestures"
+---
+
+# Gestures
+
+Gesture Handler runs recognition on the UI thread. Paired with Reanimated, a
+drag can follow the finger without a single JS-thread frame. Paired badly, it
+fights the scroll view, never fires, or leaves the UI mid-animation.
+
+## The API, and the one that was removed
+
+`useAnimatedGestureHandler` was deprecated in Reanimated 3 and **removed in
+Reanimated 4**. Code using it does not warn on 4.x; it fails to import. The
+replacement is the `Gesture` API from Gesture Handler 2:
+
+```tsx
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Draggable() {
+  const x = useSharedValue(0);
+  const start = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onStart(() => {
+      // Capture where we began, so the drag is relative rather than absolute.
+      start.value = x.value;
+    })
+    .onUpdate((e) => {
+      x.value = start.value + e.translationX;
+    })
+    .onEnd((e) => {
+      // Hand the velocity to the spring so the movement stays continuous
+      // with the finger rather than restarting from zero.
+      x.value = withSpring(0, { velocity: e.velocityX });
+    });
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.value }] }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style} />
+    </GestureDetector>
+  );
+}
+```
+
+Three things are load-bearing and easy to miss:
+
+- **`GestureDetector` must wrap an `Animated.*` component** for the style to
+  apply, and the app must be wrapped in `GestureHandlerRootView` at the root. A
+  gesture that "does nothing at all" is usually one of these two.
+- **`onStart` capturing the current value** is what makes a second drag continue
+  from where the first ended. Without it every drag jumps back to zero first.
+- **Gesture callbacks are worklets.** Everything in
+  `references/worklets-and-threads.md` applies — no direct `setState`, and be
+  deliberate about captured props and state. A `Gesture.Pan()` built inline is
+  rebuilt on every render, so what it captured is current as of the last render.
+  Freeze it — `useMemo(…, [])`, or a gesture stored in a ref — and the capture
+  freezes with it. Anything that has to change *between* renders, because the
+  gesture itself is driving it, needs a shared value either way.
+
+## Composition
+
+Gestures compose explicitly, and which one you choose decides how it feels:
+
+| | Behaviour | Use when |
+|---|---|---|
+| `Gesture.Simultaneous(a, b)` | Both run at once | Pinch and pan on a photo |
+| `Gesture.Race(a, b)` | First to activate wins, cancels the other | Tap or long-press on one item |
+| `Gesture.Exclusive(a, b)` | `a` gets priority; `b` only if `a` fails | Double-tap before single-tap |
+
+```tsx
+const zoom = Gesture.Simultaneous(Gesture.Pinch(), Gesture.Pan());
+```
+
+## Living inside a scroll view
+
+The most common real problem: a horizontal swipe inside a vertical list, where
+both want the same finger.
+
+- Give the gesture an **activation threshold** so a small movement stays with
+  the scroll view: `.activeOffsetX([-10, 10])`.
+- Use **`.failOffsetY([-5, 5])`** so a mostly-vertical movement abandons the
+  horizontal gesture rather than competing with it.
+
+```tsx
+const swipe = Gesture.Pan()
+  .activeOffsetX([-10, 10])   // horizontal intent required to activate
+  .failOffsetY([-5, 5]);      // vertical intent gives up immediately
+```
+
+Without these, swipe-to-delete inside a `FlatList` feels like the list is
+sticking, because both recognisers are alive at once.
+
+## The cases people forget
+
+**Interruption.** A finger can lift anywhere. `.onEnd` runs on a normal release;
+`.onFinalize` runs on release *and* cancellation. Reset state in `onFinalize`,
+or a cancelled gesture strands the view off-screen.
+
+```tsx
+.onFinalize(() => {
+  isPressed.value = false;
+});
+```
+
+**Unmount mid-animation.** If a spring is running when the screen goes away,
+cancel it — particularly one that schedules back to JS on completion:
+
+```tsx
+useEffect(() => () => cancelAnimation(x), []);
+```
+
+**Thresholds belong on velocity as well as distance.** A fast, short flick is a
+dismissal; a slow, long drag may not be. Judging on `translationX` alone makes
+the interaction feel unresponsive to quick gestures:
+
+```tsx
+.onEnd((e) => {
+  const dismissed = e.translationX > width * 0.4 || e.velocityX > 800;
+  x.value = withSpring(dismissed ? width : 0);
+  if (dismissed) scheduleOnRN(onDismiss, id);
+});
+```
+
+**Hit targets.** A gesture area smaller than roughly 44×44pt is hard to hit and
+fails accessibility guidance. `rn-ui-accessibility` owns the wider surface.
+
+## Accessibility
+
+A gesture that is the *only* way to reach an action excludes anyone who cannot
+perform it. Swipe-to-delete needs a reachable alternative — a long-press menu, a
+button in an expanded row — and the container needs an accessibility action so
+screen-reader users get there at all.
+
+## Auditing
+
+```bash
+# Removed in Reanimated 4 — this does not warn, it fails to import
+rg -n "useAnimatedGestureHandler" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Gestures that never reset on cancellation
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Horizontal gestures inside a scrollable, with no activation threshold
+rg -n "Gesture\.Pan\(\)" -A 8 --glob "**/*.{tsx,jsx}" | rg -L "activeOffset|failOffset"
+
+# The root wrapper, without which nothing fires
+rg -n "GestureHandlerRootView" --glob "**/{App,index,_layout}.{ts,tsx,js,jsx}"
+```

--- a/dist/windsurf/.windsurf/rules/rn-animation-layout-and-css.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation-layout-and-css.md
@@ -1,0 +1,159 @@
+---
+trigger: manual
+description: "RN Animation: Layout Animations and the CSS API"
+---
+
+# Layout Animations and the CSS API
+
+Two ways to animate without writing a shared value at all. Both are cheaper to
+write than a `useAnimatedStyle`, and both have edges worth knowing.
+
+## Entering and exiting
+
+```tsx
+import Animated, { FadeIn, FadeOutLeft, LinearTransition } from 'react-native-reanimated';
+
+<Animated.View
+  entering={FadeIn.duration(200)}
+  exiting={FadeOutLeft.duration(150)}
+  layout={LinearTransition}
+/>
+```
+
+Modifiers chain: `.duration(ms)`, `.delay(ms)`, `.easing(fn)`, `.springify()`,
+`.damping(n)`, `.withCallback(finished => …)`.
+
+`layout` animates a component's *position and size* when the surrounding layout
+changes — the thing that otherwise snaps.
+
+## The trap: lists keyed by index
+
+Entering and exiting animations fire on **mount** and **unmount**, and React
+decides which is which from the `key`. With an index key, the key set is always
+`0..n-1` — so what changes on a deletion is only the *length*.
+
+Delete `b` from `[a, b, c, d]` and the result is keyed `0,1,2`. React sees keys
+0, 1 and 2 on both sides, reuses those three components in place with new props,
+and unmounts only key 3. So:
+
+- **`b` never plays its exiting animation.** It was never unmounted — its
+  component was reused to render `c`.
+- **`d` plays the exiting animation instead**, at the bottom of the list, which
+  is nowhere near what the user deleted.
+- **The tail does not re-enter.** Positions 1 and 2 are updated, not remounted,
+  so their content swaps instantly with no transition at all.
+
+Insertion is the mirror image: prepend `z` to `[a, b, c]` and key 3 is the new
+one, so the *last* row plays the entering animation while `z` appears at the top
+with none.
+
+```tsx
+// ✗ the wrong row animates, and the row that changed does not
+{items.map((item, i) => (
+  <Animated.View key={i} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+
+// ✓ identity follows the data, so the animation lands on the row that moved
+{items.map((item) => (
+  <Animated.View key={item.id} entering={FadeIn} exiting={FadeOut} layout={LinearTransition} />
+))}
+```
+
+This is the single most common layout-animation bug, and it reads as "Reanimated
+animates the wrong row" rather than as a keying mistake. The same reuse also
+carries component state — a half-open swipe or a running spring — across to
+whichever item now occupies that position.
+
+For virtualised lists, see the library's list layout-animation guidance — a
+recycling list has its own rules, because a "new" row may be a reused one.
+
+## Entry/exit transitions
+
+`combineTransition` was removed in Reanimated 4. The replacement:
+
+```tsx
+EntryExitTransition.entering(FadeIn).exiting(FadeOut)
+```
+
+## CSS animations and transitions (Reanimated 4)
+
+Reanimated 4 added a declarative API modelled on CSS. It works alongside shared
+values — you can adopt it incrementally, and mix both in one app.
+
+```tsx
+<Animated.View
+  style={{
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+  }}
+/>
+```
+
+```tsx
+<Animated.View
+  style={{
+    animationName: {
+      from: { opacity: 0, transform: [{ scale: 0.9 }] },
+      to: { opacity: 1, transform: [{ scale: 1 }] },
+    },
+    animationDuration: 300,
+    animationIterationCount: 1,
+  }}
+/>
+```
+
+Reach for it when the animation is a **property changing over time with no
+interaction driving it** — a fade-in, a colour change on state, a pulse. Reach
+for shared values when a *gesture or scroll position* drives the value, because
+that is a continuous input the CSS API has no way to read.
+
+Not everything is animatable. Check the library's supported-properties list
+rather than assuming a style property works; an unsupported one fails quietly
+rather than loudly.
+
+## Spring behaviour changed in Reanimated 4
+
+If you are porting spring configs, three things moved at once:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` were replaced by a single
+  **`energyThreshold`**, which is relative rather than absolute. Removing the
+  old two is usually sufficient — you rarely need to set the new one.
+- **`duration` is now perceptual.** The animation actually takes about 1.5× it.
+  To reproduce previous timing, divide your old value by 1.5.
+- **The defaults changed.** If you relied on them, import
+  `Reanimated3DefaultSpringConfig` (or
+  `Reanimated3DefaultSpringConfigWithDuration`) rather than trying to
+  reconstruct them.
+
+## Reduced motion
+
+`reduceMotion` is a system accessibility setting. For some users, large motion
+causes nausea — this is not a stylistic preference.
+
+```tsx
+const reduceMotion = useReducedMotion();
+
+<Animated.View entering={reduceMotion ? undefined : SlideInRight} />
+```
+
+Honour it for anything that moves a large area, spins, parallaxes or flashes.
+A short cross-fade is usually an acceptable substitute for a large translation;
+removing feedback entirely is not, because the user still needs to know
+something changed.
+
+## Auditing
+
+```bash
+# Index-keyed lists — the animation lands on the wrong row
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Removed in Reanimated 4
+rg -n "combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs carrying the removed thresholds
+rg -n "restDisplacementThreshold|restSpeedThreshold" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Motion with no reduced-motion path anywhere in the file
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion|ReducedMotionConfig" {} || echo {}'
+```

--- a/dist/windsurf/.windsurf/rules/rn-animation-reanimated-4-migration.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation-reanimated-4-migration.md
@@ -1,0 +1,166 @@
+---
+trigger: manual
+description: "RN Animation: Reanimated 3 → 4"
+---
+
+# Reanimated 3 → 4
+
+The release notes say the API is compatible and most code needs no changes.
+That is true of *animation logic* and misleading about everything around it:
+the package set, the Babel plugin, the threading functions and two hooks all
+moved or went away.
+
+**Check `package.json` and `babel.config.js` before commenting on any API in
+this area.** The same line is correct on one major and broken on the other.
+
+## The blockers
+
+**New Architecture only.** Reanimated 4 drops the legacy renderer (Paper)
+entirely. An app that cannot move off Paper stays on the latest 3.x — that is a
+supported position, not a failure, and it is the right advice for a large app
+mid-upgrade.
+
+**There is no single React Native floor.** Support is a *moving window* per
+Reanimated minor, not a minimum you clear once. At the time of writing the table
+starts at RN 0.78, and newer Reanimated minors **drop** older React Native
+versions as they add new ones — 4.7.x supports 0.85–0.87 and does *not* support
+0.78, while 4.1.x supports 0.78–0.82 and not 0.83+. `react-native-worklets` has
+its own matrix on top, pinned tightly: 4.7.x wants worklets 0.13.x.
+
+Never quote a floor from memory, including from this page. Read the official
+compatibility table for the exact pair, or the `compatibility.json` shipped
+inside the installed Reanimated package — the table assumes the latest patch of
+each minor, and older patches differ.
+
+**Worklets are a separate package now.** Install `react-native-worklets` and
+rebuild the native apps. Match the version to the compatibility table rather
+than taking the newest.
+
+**The Babel plugin was renamed.** This one breaks everything at once and the
+error rarely names the cause:
+
+```diff
+ plugins: [
+-  'react-native-reanimated/plugin',
++  'react-native-worklets/plugin',
+ ],
+```
+
+The old path is still exported for compatibility, but the new one is what to
+use. If an upgraded app behaves as though no function is a worklet, check here
+first.
+
+## Threading functions: renamed *and* re-shaped
+
+All of these moved to `react-native-worklets`. They are re-exported from
+`react-native-reanimated` and marked deprecated.
+
+| Reanimated 3 | Reanimated 4 |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+| `makeShareableCloneRecursive` | `createSerializable` |
+
+`createWorkletRuntime`, `WorkletRuntime` and `isWorkletFunction` moved with no
+API change.
+
+**The argument shape changed too.** These were curried; they are not any more.
+A rename-only migration compiles and runs, and passes no arguments:
+
+```js
+scheduleOnRN(onDismiss)(item.id);   // ✗ schedules onDismiss with no arguments
+scheduleOnRN(onDismiss, item.id);   // ✓
+```
+
+Worth grepping for specifically, because the callback *does* fire — it just
+receives `undefined`, which surfaces later and somewhere else.
+
+## Removed
+
+| Removed | Replacement |
+|---|---|
+| `useAnimatedGestureHandler` | The `Gesture` API from Gesture Handler 2 — see `gestures.md` |
+| `useWorkletCallback` | `useCallback` with a `'worklet';` directive and a dependency array |
+| `combineTransition` | `EntryExitTransition.entering(e).exiting(x)` |
+| `react-native-v8` support | — (the engine project appears abandoned) |
+
+```jsx
+// useWorkletCallback replacement
+useCallback(() => {
+  'worklet';
+  // …
+}, [deps]);
+```
+
+If the app uses `gorhom/react-native-bottom-sheet`, it needs **5.1.8 or newer**;
+older versions depend on the removed hook.
+
+## Renamed and deprecated
+
+- `useScrollViewOffset` → **`useScrollOffset`**. The old name still works and is
+  deprecated.
+- `addWhitelistedNativeProps` / `addWhitelistedUIProps` are **no-ops** now —
+  Reanimated 4 dropped the native/UI prop distinction. Delete the calls.
+- `useAnimatedKeyboard` is marked deprecated.
+- Shared Element Transitions remain **experimental**. Treat them as such in
+  production advice.
+
+## `withSpring` behaves differently
+
+Three changes at once, which is why springs "feel wrong" after upgrading:
+
+- `restDisplacementThreshold` and `restSpeedThreshold` are gone, replaced by a
+  single relative **`energyThreshold`**. Removing the old two is normally
+  enough; you rarely need to set the new one.
+- **`duration` is perceptual.** Real completion takes about 1.5× the value.
+  Divide previous durations by 1.5 to match.
+- **Defaults changed.** To restore the old ones:
+
+```js
+import { Reanimated3DefaultSpringConfig } from 'react-native-reanimated';
+import { Reanimated3DefaultSpringConfigWithDuration } from 'react-native-reanimated';
+```
+
+## New in 4
+
+CSS animations and transitions — a declarative API alongside shared values,
+adoptable incrementally. See `layout-and-css.md`.
+
+## A migration order that works
+
+1. Confirm the New Architecture is on, then look up your exact React Native
+   version in the compatibility table to find which Reanimated 4 minor supports
+   it. If none does, stop here and stay on 3.x — everything below is wasted.
+2. Install `react-native-worklets` at the matching version; rebuild native.
+3. Change the Babel plugin. Clear the Metro cache (`--reset-cache`).
+4. Replace `useAnimatedGestureHandler` and `useWorkletCallback` — these are hard
+   failures, so they surface immediately.
+5. Update the threading calls, **checking the argument shape at each one**, not
+   just the name.
+6. Delete `addWhitelistedNativeProps` / `addWhitelistedUIProps` calls.
+7. Remove `restDisplacementThreshold` / `restSpeedThreshold`; divide spring
+   `duration` values by 1.5.
+8. Exercise every gesture and spring by hand. None of the above is caught by a
+   type check, and most of it is not caught by tests either.
+
+## Auditing
+
+```bash
+# Hard failures on 4.x
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Deprecated threading imports still coming from reanimated
+rg -n "import \{[^}]*(runOnJS|runOnUI|runOnRuntime|executeOnUIRuntimeSync)[^}]*\} from 'react-native-reanimated'"
+
+# The curried-call hazard after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Spring configs and no-ops that no longer do anything
+rg -n "restDisplacementThreshold|restSpeedThreshold|addWhitelisted\w+Props" --glob "**/*.{ts,tsx,js,jsx}"
+
+# The plugin, and the versions that decide all of the above
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+node -p "Object.fromEntries(Object.entries(require('./package.json').dependencies).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+```

--- a/dist/windsurf/.windsurf/rules/rn-animation-reviewing-animation-code.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation-reviewing-animation-code.md
@@ -1,0 +1,117 @@
+---
+trigger: manual
+description: "RN Animation: Reviewing Animation Code"
+---
+
+# Reviewing Animation Code
+
+What to look for, roughly in the order that finds real problems fastest.
+Correctness before smoothness: a 60fps animation of the wrong value is not an
+improvement on a janky correct one.
+
+## 1. Versions, before anything else
+
+```bash
+node -p "Object.fromEntries(Object.entries({...require('./package.json').dependencies}).filter(([k])=>/reanimated|worklets|gesture-handler/.test(k)))"
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```
+
+Reanimated 4 removed `useAnimatedGestureHandler` and `useWorkletCallback`,
+renamed the Babel plugin, and re-shaped the threading functions. Commenting on
+an API without knowing the major version produces confident, wrong findings.
+
+## 2. The thread boundary
+
+The highest-yield read. For each worklet — `useAnimatedStyle`,
+`useDerivedValue`, `useAnimatedReaction`, gesture callbacks, anything with
+`'worklet';` — ask what it captured.
+
+| Look for | Why it is wrong |
+|---|---|
+| A `useState` value or prop inside a worklet with a **frozen dependency list** — `useMemo(…, [])`, a gesture built once, `useCallback(…, [])` | Captured by copy at creation. A Reanimated hook normally re-creates its worklet when its dependencies change, so the copy refreshes on re-render; an empty or hand-written dependency list is what stops that and pins the first value forever |
+| A captured value that has to change **between** renders — driven by the gesture or the animation itself | No re-render happens, so nothing re-creates the worklet. This is what a shared value is for, and the one case where "use a shared value" is the answer regardless of dependencies |
+| `ref.current` inside a worklet | Refs deliberately do not trigger a re-render, so the worklet is never re-created and the copy is genuinely frozen |
+| `setState` called directly from a worklet | Does not cross the boundary; needs `scheduleOnRN`/`runOnJS` |
+| `scheduleOnRN(fn)(args)` | Arguments are no longer curried — the call passes none |
+| Scheduling back to JS inside `onUpdate` | Per-frame JS work, defeating the point of UI-thread gestures |
+| `useAnimatedReaction` with no previous-value comparison | Fires every frame the prepared value changes |
+
+## 3. Interruption and unmount
+
+- Does the gesture reset on **cancellation**, not only on a normal end? Look for
+  `.onFinalize`, not just `.onEnd`.
+- Is a running animation **cancelled on unmount** if it schedules a callback?
+- Does the component handle being re-rendered mid-animation?
+
+The happy path is not where animation bugs live. Fingers lift, calls arrive,
+users press back.
+
+## 4. Lists
+
+- A list keyed by **index** animates the wrong row. Index keys make the key set
+  depend only on the length, so React reuses the surviving positions in place and
+  mounts or unmounts at the end: the deleted row never plays `exiting`, the last
+  row does, and a prepended row never plays `entering`. Look for `key={i}`.
+- `layout` on a large list is expensive. On a virtualised list it may fight
+  recycling.
+
+## 5. Accessibility
+
+- `useReducedMotion` honoured for large movement, spin, parallax or flashing.
+- A gesture is not the *only* route to an action.
+- Hit areas around 44×44pt or larger.
+
+## 6. Only then, cost
+
+Ask what runs per frame. A worklet doing layout maths every frame blocks the UI
+thread — the same thread that draws — so it degrades exactly what it was
+supposed to protect.
+
+For frame budgets, profiling and measurement methodology, use **`rn-performance`**.
+It owns the "why is this janky" question; this agent owns "is this correct".
+
+## Severity, calibrated
+
+| | Example |
+|---|---|
+| **P0** | Gesture leaves the UI unusable — a modal that can be dragged off-screen with no way back |
+| **P1** | Worklet captures stale state, so the animation shows the wrong value; a removed-in-4 API on a 4.x app |
+| **P2** | No cancellation path; index-keyed lists animating the wrong row; reduced motion ignored on large movement |
+| **P3** | A spring config that could be tuned; a `withTiming` that would read better as a CSS transition |
+
+Do not inflate. A janky animation is not a P0 unless the screen is unusable.
+
+## What not to report
+
+- **Style preferences.** "I would use `withSpring` here" is not a finding.
+- **Library migrations nobody asked for.** Moving a working `Animated` API
+  animation to Reanimated is a project, not a review comment — unless the code
+  is *already* broken by it.
+- **Invented numbers.** No frame counts, no millisecond figures, no "30% smoother"
+  unless it was measured. Say what to measure with instead.
+- **Confirmations.** "Correctly uses a shared value" is not a finding. If the
+  code is right, say so in the summary or say nothing.
+
+## The greps worth running first
+
+```bash
+# Removed in 4 — hard failures
+rg -n "useAnimatedGestureHandler|useWorkletCallback|combineTransition" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Curried threading calls after a rename-only migration
+rg -n "scheduleOn(RN|UI|Runtime)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue|onUpdate|onEnd" -A 6 --glob "**/*.{tsx,jsx}" \
+  | rg "useState|props\.|\.current"
+
+# Gestures with no cancellation path
+rg -n "Gesture\.\w+\(\)" -A 20 --glob "**/*.{tsx,jsx}" | rg -L "onFinalize"
+
+# Index-keyed entering animations
+rg -n "entering=" -B 3 --glob "**/*.{tsx,jsx}" | rg "key=\{(i|idx|index)\}"
+
+# Motion with no reduced-motion path
+rg -ln "entering=|withRepeat|SlideIn|ZoomIn" --glob "**/*.{tsx,jsx}" \
+  | xargs -I{} sh -c 'rg -q "useReducedMotion" {} || echo {}'
+```

--- a/dist/windsurf/.windsurf/rules/rn-animation-worklets-and-threads.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation-worklets-and-threads.md
@@ -1,0 +1,217 @@
+---
+trigger: manual
+description: "RN Animation: Worklets and the Thread Boundary"
+---
+
+# Worklets and the Thread Boundary
+
+Everything in this file follows from one fact: **Reanimated runs your animation
+code in a second JavaScript runtime on the UI thread.** Not a worker, not a
+callback — a separate runtime with its own copy of the values it captured.
+
+Almost every "my animation is broken" question is a boundary mistake.
+
+## Three separate questions
+
+These get conflated constantly, including by people who have used Reanimated for
+years. They are independent:
+
+1. **Is the function workletized?** The `'worklet';` directive, or automatic
+   handling by the Worklets Babel plugin, makes a function *serializable* — able
+   to be copied into the UI runtime.
+2. **Where is it scheduled?** The API you hand it to decides. `useAnimatedStyle`
+   schedules on the UI thread. `scheduleOnRN` schedules on the React Native JS
+   thread. A workletized function you simply *call* runs wherever the caller is.
+3. **Where is it running right now?** Not always the same answer twice. The
+   `useAnimatedStyle` callback runs **first on the JS thread, then immediately
+   on the UI thread**. Code that assumes UI-thread-only will break on that first
+   pass. Reanimated exposes `global._WORKLET` precisely because the answer is
+   not static:
+
+```js
+const style = useAnimatedStyle(() => {
+  if (global._WORKLET) {
+    // UI thread
+  } else {
+    // the first, JS-thread pass
+  }
+});
+```
+
+Being workletized does **not** mean "runs on the UI thread". Gesture Handler can
+be told to run its callbacks on the JS thread instead. The directive is about
+serializability; the scheduling API is about placement.
+
+## Where things usually run
+
+Treat this as the default, not a guarantee — the section above is why.
+
+| Usually the **UI thread** | The **JS thread** |
+|---|---|
+| `useAnimatedStyle` body (after its first pass) | Component render |
+| `useAnimatedProps` body | `useEffect`, state setters |
+| `useDerivedValue` body | Anything scheduled with `scheduleOnRN` |
+| `useAnimatedReaction` bodies | A worklet you call directly from JS |
+| `useAnimatedScrollHandler` body | Gesture callbacks configured to run on JS |
+| Gesture callbacks (by default) | |
+
+## What a worklet captures, and when it refreshes
+
+This is the part most often stated too strongly — including in earlier versions
+of this document.
+
+A **serialized worklet instance** captures its variables by copy. But the
+Reanimated hooks **re-create their worklet when their dependencies change**, and
+the Babel plugin infers those dependencies from the function body. The official
+description of `useAnimatedStyle` is that styles update "whenever an associated
+shared value **or React state** changes".
+
+So this works:
+
+```tsx
+// ✓ `opacity` is captured, but the hook re-creates the worklet on re-render,
+//    so a state change is reflected.
+const [opacity, setOpacity] = useState(1);
+const style = useAnimatedStyle(() => ({ opacity }));
+```
+
+What captured values **cannot** do is change *between* renders. That is the real
+distinction, and it is what shared values are for:
+
+```tsx
+// ✗ The UI thread cannot move this. Only a re-render can, and a gesture
+//   running at 120Hz must not cause 120 re-renders.
+const [x, setX] = useState(0);
+
+// ✓ A shared value is written from the UI thread with no render at all.
+const x = useSharedValue(0);
+```
+
+**Where staleness does bite** is when a worklet is created once and kept:
+
+```tsx
+// ✗ Empty dependency array: this gesture object is built on the first render
+//   and never again, so `isDeleting` is pinned to its first value forever.
+const pan = useMemo(
+  () => Gesture.Pan().onEnd(() => {
+    if (!isDeleting) scheduleOnRN(onDelete, id);
+  }),
+  [],
+);
+
+// ✓ Either list the dependencies, or read from a shared value.
+const pan = useMemo(() => Gesture.Pan().onEnd(() => { … }), [isDeleting, id]);
+```
+
+The rule to apply, then, is not "captured values are frozen". It is:
+
+- **Driven by React?** A captured prop or state value is fine — the hook
+  refreshes it.
+- **Driven by the UI thread between renders** — a gesture, a running animation?
+  It must be a shared value.
+- **Memoised with a stale dependency list?** That is where a genuine stale
+  capture comes from, and it is a dependency-array bug, not a Reanimated one.
+
+## Calling back into React
+
+The UI thread cannot touch React state. Scheduling is explicit, and **this is
+the API that changed in Reanimated 4**:
+
+```tsx
+// Reanimated 4 — from react-native-worklets. Arguments are NOT curried.
+import { scheduleOnRN } from 'react-native-worklets';
+
+const gesture = Gesture.Pan().onEnd((e) => {
+  'worklet';
+  if (e.translationX > THRESHOLD) {
+    scheduleOnRN(onDismiss, item.id);
+  }
+});
+```
+
+```tsx
+// Reanimated 3 — the curried form. Still re-exported in 4, but deprecated.
+import { runOnJS } from 'react-native-reanimated';
+
+runOnJS(onDismiss)(item.id);
+```
+
+Note the shape change: `runOnJS(fn)(args)` became `scheduleOnRN(fn, args)`. A
+mechanical find-and-replace of the *name* alone produces a call that schedules a
+function with no arguments — which usually fails silently, because the callback
+does run.
+
+Going the other way:
+
+| Reanimated 3 | Reanimated 4 (`react-native-worklets`) |
+|---|---|
+| `runOnJS(fn)(a, b)` | `scheduleOnRN(fn, a, b)` |
+| `runOnUI(fn)(a)` | `scheduleOnUI(fn, a)` |
+| `executeOnUIRuntimeSync(fn)(a)` | `runOnUISync(fn, a)` |
+| `runOnRuntime(rt, fn)(a)` | `scheduleOnRuntime(rt, fn, a)` |
+
+Two things worth saying about scheduling back to JS:
+
+- **It is asynchronous.** Do not schedule and then read the result on the next
+  line of the worklet.
+- **It costs a hop per call.** Scheduling on every frame of a gesture defeats
+  the reason the gesture is on the UI thread at all. Schedule on
+  *transitions* — `onEnd`, a threshold being crossed — not on `onUpdate`.
+
+## Reacting to a shared value without rendering
+
+`useAnimatedReaction` watches a value on the UI thread and runs when it changes.
+Use it when a change should cause something other than a style update:
+
+```tsx
+useAnimatedReaction(
+  () => scrollY.value > HEADER_HEIGHT,          // prepare: cheap, pure
+  (isCollapsed, wasCollapsed) => {              // react: only when it changes
+    if (isCollapsed !== wasCollapsed) {
+      scheduleOnRN(setHeaderCollapsed, isCollapsed);
+    }
+  },
+);
+```
+
+The guard matters. The reaction fires on every change of the *prepared* value,
+and without comparing against the previous one you will schedule a React state
+update on every frame — reintroducing exactly the JS-thread work the animation
+was moved off it to avoid.
+
+## Deriving instead of duplicating
+
+`useDerivedValue` produces a shared value computed from others, on the UI
+thread. Prefer it to keeping two shared values in sync by hand:
+
+```tsx
+const progress = useDerivedValue(() => clamp(scrollY.value / HEADER_HEIGHT, 0, 1));
+```
+
+## What breaks and how it looks
+
+| Symptom | Usual cause |
+|---|---|
+| Animation ignores a state change | The worklet is not being re-created: a frozen dependency list (`useMemo(…, [])`, a gesture built once), or a value that has to change between renders and so needs a shared value |
+| Callback never runs | Called a JS function directly from a worklet instead of scheduling it |
+| Callback runs with `undefined` arguments | Migrated `runOnJS(fn)(a)` to `scheduleOnRN(fn)(a)` — arguments are no longer curried |
+| "Tried to synchronously call a non-worklet function" | A non-worklet function called from the UI thread |
+| Value updates but nothing moves | Style not applied via `useAnimatedStyle`, or the component is not an `Animated.*` |
+| Works in dev, janky in release | Heavy work inside a worklet — it blocks the UI thread |
+| Everything broke after upgrading | Babel plugin still `react-native-reanimated/plugin`; Reanimated 4 needs `react-native-worklets/plugin` |
+
+## Auditing
+
+```bash
+# State setters called from somewhere that may be the UI thread
+rg -n "set[A-Z]\w*\(" --glob "**/*.{ts,tsx,js,jsx}" -B 4 | rg -B 4 "worklet|onUpdate|onEnd|useAnimatedStyle"
+
+# The un-curried migration hazard: a name change without a shape change
+rg -n "scheduleOn(RN|UI)\([^)]*\)\s*\(" --glob "**/*.{ts,tsx,js,jsx}"
+
+# Worklets capturing component state
+rg -n "useAnimatedStyle|useDerivedValue" -A 6 --glob "**/*.{tsx,jsx}" | rg "useState|props\.|\.current"
+
+# The Babel plugin, which decides whether any of this works at all
+rg -n "reanimated/plugin|worklets/plugin" babel.config.js
+```

--- a/dist/windsurf/.windsurf/rules/rn-animation.md
+++ b/dist/windsurf/.windsurf/rules/rn-animation.md
@@ -1,0 +1,106 @@
+---
+trigger: model_decision
+description: Use for writing and reviewing React Native animation and gesture code — Reanimated worklets and shared values, the JS/UI thread boundary, the Gesture Handler API, layout and entering/exiting animations, scroll-driven motion, and the Reanimated 4 migration. Covers the failure modes that look like bugs in your logic but are really thread-boundary mistakes.
+globs: "**/*.{ts,tsx,js,jsx},**/babel.config.js,**/package.json"
+---
+
+You are a React Native animation engineer. You write and review Reanimated and
+Gesture Handler code.
+
+## What makes this area different
+
+Almost every animation bug in React Native is a **thread-boundary** bug wearing
+the costume of a logic bug.
+
+Reanimated runs your animation code on the UI thread, in a separate JavaScript
+runtime, on a *copy* of the values it captured. Your component code runs on the
+JS thread. The two share nothing except shared values and explicitly scheduled
+calls. When someone says "my animation doesn't update", "my callback never
+fires", or "the value is stale", the answer is almost always that they crossed
+that boundary without noticing.
+
+So the first question is never "what does this animation do?". It is **which
+thread is this line running on, and what does it have access to there?**
+
+## Method
+
+**0 — Establish the versions before commenting on any API.** Read `package.json`
+for `react-native-reanimated`, `react-native-worklets` and
+`react-native-gesture-handler`, and check `babel.config.js`. Reanimated 4 renamed
+the Babel plugin, moved worklet functions to a separate package, and **removed**
+`useAnimatedGestureHandler` and `useWorkletCallback`. The same line of code is
+correct on 3.x and broken on 4.x, and vice versa. State the versions you found.
+See `references/reanimated-4-migration.md`.
+
+**1 — Separate three questions that get conflated.** Being *workletized* (the
+`'worklet';` directive) only makes a function serializable. *Where it is
+scheduled* is decided by the API you hand it to. *Where it is running* can differ even
+within one function — the `useAnimatedStyle` callback runs first on the JS
+thread and then on the UI thread, which is why `global._WORKLET` exists. Gesture
+callbacks can also be configured to run on JS. Label each function with all
+three before reasoning about it.
+
+**2 — Ask what drives the value, not just where it is captured.** Reanimated
+hooks re-create their worklet when their dependencies change, and the Babel
+plugin infers those dependencies — so a captured prop or state value *does*
+refresh on re-render. What a captured value cannot do is change **between**
+renders, which is what a gesture at 120Hz needs. Shared values exist for that
+case, not for every capture. Genuine staleness comes from a worklet pinned by an
+empty or incomplete dependency array.
+
+**3 — Check what happens when the gesture is interrupted.** Fingers lift
+mid-drag, calls arrive, screens unmount, users go back. An animation that only
+handles the happy path leaves the UI in a wrong position, and it is the state
+users actually hit.
+
+**4 — Then performance.** Whether it holds 60fps matters, but a smooth animation
+of the wrong value is not better than a janky correct one. `rn-performance` owns
+frame-budget analysis and profiling; come here for whether the code is *right*.
+
+**5 — Then accessibility.** Reduced-motion is a system setting, not a
+preference to ignore. `rn-ui-accessibility` owns the wider surface.
+
+## What you always check
+
+- **Anything the UI thread must change between renders is a shared value.** A
+  captured prop or state value refreshes when the hook's dependencies change, so
+  it is fine for React-driven changes — but a gesture cannot move it without a
+  re-render per frame.
+- **Worklets held across renders list their dependencies.** A gesture built
+  inside `useMemo(..., [])` captures its first values and keeps them. That is a
+  dependency-array bug, and it is where real staleness lives.
+- **Anything touching React state from the UI thread is scheduled explicitly.**
+  Calling `setState` directly inside a worklet does not work. It needs
+  `scheduleOnRN` (Reanimated 4) or `runOnJS` (3.x) — and the two have different
+  call signatures, which is a common silent break during migration.
+- **Gesture handlers are attached to a `GestureDetector`,** with
+  `react-native-gesture-handler` set up at the app root. A gesture that "does
+  nothing" is usually not wired to a detector, or the root wrapper is missing.
+- **Animations are cancelled when the component unmounts** if they hold a
+  reference to anything that outlives them.
+- **List keys follow the data, not the position.** With an index key the key set
+  depends only on the length, so React reuses the surviving rows in place and
+  mounts or unmounts at the end — the animation lands on the last row rather than
+  the one that actually changed.
+- **`reduceMotion` is honoured** for anything that moves a large area, spins, or
+  flashes. It is an accessibility setting, and for some users a vestibular one.
+
+## What you never do
+
+- **Never claim an API exists without checking the installed version.** This
+  library renamed its threading functions, moved them to a new package, and
+  removed two hooks in its last major. Guessing here produces confident,
+  wrong, expensive-to-debug advice.
+- **Never invent frame timings, dropped-frame counts or millisecond figures.**
+  If it was not measured, say it was not measured, and say what to measure with.
+- **Never recommend rewriting a working animation in a different library**
+  because it would be "cleaner". Say what is wrong with the current one, or say
+  nothing.
+- **Never move logic to the UI thread for speed without saying what it costs.**
+  UI-thread work blocks rendering. A heavy worklet is worse than a JS callback.
+
+## Output
+
+For a review, report only what is wrong, with the file and line. For authoring,
+give the code and the reasoning that made you choose it — especially which
+thread each part runs on, because that is what the next reader will need.

--- a/dist/windsurf/.windsurf/rules/rn-performance-animations-and-gestures.md
+++ b/dist/windsurf/.windsurf/rules/rn-performance-animations-and-gestures.md
@@ -5,58 +5,59 @@ description: "RN Performance: Animations and Gestures"
 
 # Animations and Gestures
 
-The rule is simple: **animations must run on the UI thread.** If a frame's value has to make a
-round trip to the JS thread, any JS work — a render, a fetch callback, a JSON parse — drops
-frames. On a 120Hz display you have 8.3ms per frame; a single React commit can eat all of it.
+The goal is that **per-frame values are produced without a round trip to the JS
+thread.** When a frame's value has to make that trip, any JS work — a render, a
+fetch callback, a JSON parse — can delay it and drop frames. On a 120Hz display
+the budget is 8.3ms per frame; a single React commit can eat all of it.
+
+"Runs on the UI thread" is a property of the *API and how it was configured*, not
+of the library. Reanimated schedules worklets on the UI thread, but a
+`useAnimatedStyle` callback also runs once on the JS thread, gesture callbacks
+can be configured to run on JS, and core `Animated` runs natively only with
+`useNativeDriver: true`. Check the configuration before assuming the thread.
 
 ## Library choice
 
 | Library | Use |
 |---|---|
-| **Reanimated 3/4** | Default for anything non-trivial. Worklets run on the UI thread. |
-| **Gesture Handler** | Default for all touch handling. Runs on the UI thread, composes with Reanimated. |
+| **Reanimated 3/4** | Default for anything non-trivial. Worklets are scheduled on the UI thread by the animation APIs. |
+| **Gesture Handler** | Default for all touch handling. Recognition is native and callbacks are worklets by default, so they can be kept off JS; composes with Reanimated. |
 | `Animated` (core) | Fine for simple one-shot transitions **with `useNativeDriver: true`**. |
 | `LayoutAnimation` | Legacy; unreliable on Fabric. Prefer Reanimated layout animations. |
 | `PanResponder` | Legacy. JS-thread gesture handling — replace it. |
 
-## Reanimated correctness
+## Cost, not correctness
 
-```tsx
-const offset = useSharedValue(0);
+**Whether the animation code is *correct* — worklets, the thread boundary, the
+Gesture API, `scheduleOnRN` vs `runOnJS`, the Reanimated 4 migration — belongs to
+`rn-animation`.** That agent owns authoring and review; this one owns "why is it
+janky". Sending a stale-closure bug here produces a frame-budget answer to a
+correctness question.
 
-const style = useAnimatedStyle(() => ({
-  transform: [{ translateX: offset.value }],
-}));
-
-// driving it
-offset.value = withSpring(100, { damping: 15, stiffness: 120 });
-```
-
-Common mistakes:
-
-- **Reading `.value` during render.** `<View style={{ left: offset.value }} />` reads once and
-  never updates, and warns. Always go through `useAnimatedStyle`.
-- **`runOnJS` inside a per-frame callback.** Every call schedules work on the JS thread; in a
-  `useAnimatedReaction` or scroll handler that's 60–120 JS hops per second. Only call `runOnJS`
-  at gesture boundaries (start/end) or debounced.
-- **Capturing non-worklet values.** Worklets serialise their closure. Capturing a large object,
-  or a function that isn't a worklet, either throws or copies more than you expect. Capture
-  primitives and shared values.
-- **Missing the Babel plugin.** `react-native-reanimated/plugin` must be **last** in
-  `babel.config.js` plugins. Without it, worklets silently run on JS.
-- **Animating layout properties.** `width`, `height`, `top`, `left`, `margin`, `padding` trigger
-  layout on every frame. Animate `transform` and `opacity` — they're composited, not laid out.
+What matters *for performance* is which properties you animate:
 
 ```tsx
 // ✗ layout pass per frame
 useAnimatedStyle(() => ({ width: w.value, marginTop: m.value }))
 
-// ✓ composited
+// ✓ composited — no layout, no paint
 useAnimatedStyle(() => ({
   transform: [{ scaleX: sx.value }, { translateY: ty.value }],
   opacity: o.value,
 }))
 ```
+
+`width`, `height`, `top`, `left`, `margin` and `padding` trigger layout on every
+frame. `transform` and `opacity` are composited.
+
+Two other costs worth measuring before assuming:
+
+- **Scheduling back to the JS thread per frame.** In a scroll handler or a
+  `useAnimatedReaction`, that is 60–120 hops a second, and it puts the work back
+  on the thread the animation was moved off. Schedule at boundaries, not on
+  every update.
+- **Heavy work inside a worklet.** The UI thread also draws. A worklet doing
+  real computation every frame degrades exactly what it was meant to protect.
 
 ## Scroll-driven animation
 
@@ -85,23 +86,21 @@ Animated.timing(value, {
 find `useNativeDriver: false`, that animation is running frame-by-frame on the JS thread — either
 switch the animated property or move to Reanimated.
 
-## Gesture Handler
+## Gesture Handler — the performance angle
 
-```tsx
-const pan = Gesture.Pan()
-  .onUpdate((e) => { offset.value = e.translationX; })     // worklet, UI thread
-  .onEnd(() => { offset.value = withSpring(0); });
+The Gesture API itself, composition, cancellation and scroll-view relations are
+`rn-animation`'s. What matters here is that gesture recognition and the
+resulting updates stay on the UI thread:
 
-<GestureDetector gesture={pan}>
-  <Animated.View style={style} />
-</GestureDetector>
-```
-
-- Compose with `Gesture.Simultaneous`, `Gesture.Race`, `Gesture.Exclusive` instead of manual
-  flag juggling.
-- `Pressable`/`TouchableOpacity` are fine for taps; don't rebuild them with gestures.
-- Gestures nested inside scrollables need explicit relations (`.blocksExternalGesture`,
-  `.simultaneousWithExternalGesture`) or you get scroll-vs-drag fights.
+- A gesture callback is a worklet by default. Writing a shared value in
+  `.onUpdate` is cheap — it stays on the UI thread and does not re-render — but
+  it is not free: it still drives the style recomputation and whatever that
+  callback does. Scheduling back to JS there costs a hop per frame on top.
+- Gestures nested inside scrollables need explicit relations
+  (`.blocksExternalGesture`, `.simultaneousWithExternalGesture`) or both
+  recognisers stay alive and the list feels like it is sticking.
+- `Pressable`/`TouchableOpacity` are fine for taps. Rebuilding them with
+  gestures buys nothing and costs correctness.
 
 ## Navigation transitions
 
@@ -146,5 +145,7 @@ rg 'PanResponder'
 rg 'LayoutAnimation'
 rg 'runOnJS' -B 3                       # check the calling context
 rg 'onScroll=\{\(' --type tsx           # JS-thread scroll handlers
-rg 'reanimated/plugin' babel.config.js  # must be last in the list
+# Reanimated 4 renamed this to react-native-worklets/plugin; either way it must
+# be last in the list. A config with neither is a config where no worklet works.
+rg 'react-native-(reanimated|worklets)/plugin' babel.config.js
 ```

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -62,6 +62,14 @@ Its premise is that **most monorepo errors are one of four causes wearing the sa
 
 Command: `/rn-monorepo`
 
+## Animation — `rn-animation`
+
+Use for writing and reviewing Reanimated and Gesture Handler code — worklets, shared values, the JS/UI thread boundary, gestures, layout and entering/exiting animations, and the Reanimated 4 migration.
+
+Almost every animation bug is a thread-boundary bug wearing the costume of a logic bug, so the agent labels which thread each function runs on before anything else. It covers stale worklet closures, `scheduleOnRN` versus `runOnJS` and their differing call shapes, gesture composition and cancellation, index-keyed list flicker, and reduced motion. `rn-performance` owns "why is this janky"; this one owns "is this correct".
+
+Command: `/rn-animate`
+
 ## Performance — `rn-performance`
 
 Use for slow lists, dropped frames, startup/TTI, memory growth, bundle size, images, animations, and network work.

--- a/evals/README.md
+++ b/evals/README.md
@@ -97,6 +97,28 @@ match:
 }
 ```
 
+**`unlessAnywhere` — document-scoped, for rules whose claim is document-scoped.**
+Clause scope is the right default, but it cannot express every rule. Two rules
+assert an *absence across the whole answer* — "recommends the swap without
+mentioning migration **at all**", "presents the migration **as free**" — and
+their trigger is a bare product name. Clause scope made them look for the
+exception in the one place a discussion of migration cost will almost never be,
+so both reported violations against answers that did discuss it a sentence
+later. The rule name promised one scope and the mechanism enforced another.
+
+```json
+{
+  "name": "recommends the swap without mentioning migration at all",
+  "all": ["mmkv"],
+  "unlessAnywhere": "\\bmigrat\\w+|\\bexisting data\\b|\\bupgrade path\\b"
+}
+```
+
+`--validate` **rejects** `unlessAnywhere` alongside a specific `pattern`, or
+alongside `unlessPattern`. Whole-response exceptions are for bare-term rules
+only; bolting one onto an already-precise pattern is how "a legitimate word
+anywhere excuses everything" comes back, which is the exact failure below.
+
 **`unless` — removed.** It took a list of keywords and excused the violation if
 any appeared nearby. That asks "does a negation-ish word appear?", which is a
 semantic question keywords cannot answer. Five bypasses were reported against
@@ -125,6 +147,12 @@ only as careful as the regex someone wrote:
   duplicate, remove `node_modules`" is a correct answer, and the qualifier is in
   its own clause. A preceding clause ending in a full stop does *not* count —
   allowing that would reopen the first bypass in the table.
+- **The clause is found by where the match ends,** not by searching for the
+  evidence text. A pattern anchored to the opening of the response —
+  `^[\s\S]{0,350}…`, which is how "as the first step" is expressed — matches a
+  span covering many clauses, so a substring search found none of them and the
+  exception could never apply. Everything before the match end is positional
+  context; the advice is where the match lands.
 
 ## What makes the suite fail
 

--- a/evals/animation/clean-drag-handle/case.json
+++ b/evals/animation/clean-drag-handle/case.json
@@ -1,0 +1,60 @@
+{
+  "agent": "rn-animation",
+  "title": "A correct drag handle — nothing to report",
+  "context": {
+    "reactNative": "0.87",
+    "language": "TypeScript"
+  },
+  "notes": "Clean case. Only shared values cross the thread boundary. onDismiss is carried as the dismissal spring's completion callback and guarded on `finished`, so it fires when the sheet has actually left rather than while it is still on screen, and cancelAnimation on unmount runs it with finished === false — which is what makes the cleanup meaningful. scheduleOnRN is called once at that boundary rather than per frame, with un-curried arguments. onStart captures the starting offset so a second drag continues. Dismissal is judged on velocity as well as distance. onFinalize resets y only on cancellation, so it does not fight the dismissal spring. The style animates transform and opacity, both composited. Reduced motion is honoured and the gesture is not the only route to the action. The failure mode being tested is manufacturing findings: objecting to the inline opacity maths, demanding useDerivedValue, calling the velocity threshold a magic number, or claiming runOnJS should have been used.",
+  "expect": [],
+  "expectMaxFindings": 1,
+  "expectSeverity": [],
+  "forbid": [
+    {
+      "name": "claims a value is stale or captured when only shared values cross",
+      "pattern": "(stale|captured|frozen)\\s+\\w{0,12}\\s*(closure|value|state|prop)|(closure|value|state|prop)\\s+\\w{0,12}\\s*(is|are)\\s+(stale|captured|frozen)",
+      "unlessPattern": "(?:is|are)\\s+not\\s+(?:stale|captured|frozen)|correctly\\s+\\w+|no stale"
+    },
+    {
+      "name": "recommends runOnJS over the current scheduleOnRN",
+      "pattern": "(use|should use|switch to|replace with)\\s+runonjs",
+      "unlessPattern": "(?:do not|don't|avoid|never)\\s+\\w{0,15}\\s*use|\\bdeprecated\\b|\\bolder\\b"
+    },
+    {
+      "name": "claims the gesture has no cancellation path",
+      "pattern": "(missing|no|never|add)\\s+.{0,20}(onfinalize|cancellation|cleanup)",
+      "unlessPattern": "(?:is|are)\\s+(?:present|handled|correct)|already\\s+\\w+"
+    },
+    {
+      "name": "objects to animating transform or opacity",
+      "pattern": "(avoid|do not|should not)\\s+.{0,25}(transform|opacity)",
+      "unlessPattern": "(?:is|are)\\s+(?:correct|fine|composited|right)"
+    },
+    {
+      "name": "demands the inline interpolation be extracted",
+      "pattern": "(should|must|extract)\\s+.{0,30}(usederivedvalue|interpolate)",
+      "unlessPattern": "(?:is|are)\\s+(?:fine|correct|optional)|\\bnot (?:necessary|needed|required)\\b"
+    },
+    {
+      "name": "invents a frame rate or millisecond figure",
+      "pattern": "\\b\\d+\\s?(fps|ms|milliseconds)\\b",
+      "unlessPattern": "(?:for example|e\\.?g\\.?|such as|roughly|approximately|measure\\w*)"
+    },
+    {
+      "name": "asserts that captured props or state are always stale in a worklet",
+      "pattern": "(captured|worklet)\\w*[^.;,]{0,40}(always|never)\\s+(stale|updates?|refresh)",
+      "unlessPattern": "(?:re-?creat|refresh)\\w*[^.;,]{0,30}(?:dependenc|render)"
+    },
+    {
+      "name": "claims onDismiss fires before the animation completes",
+      "pattern": "(onDismiss|dismiss(al)?\\s+callback)[^.;]{0,60}(before|prematurely|too early|while)[^.;]{0,40}(spring|animation|complet|finish)",
+      "unlessPattern": "(?:is|are)\\s+(?:correctly|properly)|(?:completion|finished)\\s+callback|\\bnot\\b[^.;]{0,20}(?:before|early)"
+    },
+    {
+      "name": "calls the unmount cancelAnimation unnecessary",
+      "pattern": "(cancelanimation|cleanup|useeffect)[^.;]{0,50}(unnecessary|not needed|redundant|pointless|no-?op)",
+      "unlessPattern": "(?:is|are)\\s+(?:necessary|needed|correct|right)"
+    }
+  ],
+  "elidedHelpers": []
+}

--- a/evals/animation/clean-drag-handle/input.tsx
+++ b/evals/animation/clean-drag-handle/input.tsx
@@ -1,0 +1,89 @@
+// DragHandle.tsx — a draggable sheet handle.
+// Everything here is on the correct thread. There is nothing worth reporting.
+import React, { useEffect } from 'react';
+import { useReducedMotion } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
+
+const DISMISS_DISTANCE = 140;
+const DISMISS_VELOCITY = 800;
+
+export function DragHandle({ onDismiss, height }) {
+  // Shared values are the only thing that stays live across the boundary.
+  const y = useSharedValue(0);
+  const start = useSharedValue(0);
+  const reduceMotion = useReducedMotion();
+
+  // The dismissal spring below carries `onDismiss` as its completion callback,
+  // so a live animation holds a reference to it. Cancelling on unmount runs that
+  // callback with finished === false, which the guard there rejects — a sheet
+  // closed by other means cannot fire onDismiss after it is gone.
+  useEffect(() => () => cancelAnimation(y), []);
+
+  const pan = Gesture.Pan()
+    // Vertical intent required, and a mostly-horizontal drag gives up
+    // immediately rather than competing with the content underneath.
+    .activeOffsetY([-10, 10])
+    .failOffsetX([-5, 5])
+    .onStart(() => {
+      // Capture where this drag began so a second drag continues rather than
+      // jumping back to zero.
+      start.value = y.value;
+    })
+    .onUpdate((e) => {
+      y.value = start.value + e.translationY;
+    })
+    .onEnd((e) => {
+      // Velocity as well as distance: a short flick is a dismissal too.
+      const dismissed =
+        e.translationY > DISMISS_DISTANCE || e.velocityY > DISMISS_VELOCITY;
+
+      if (dismissed) {
+        // Fired from the spring's completion callback, not here — the sheet is
+        // still visibly on screen at this point, and unmounting it now would cut
+        // the animation off part-way. `finished` is false when the spring was
+        // cancelled or replaced, which is what keeps the unmount path safe.
+        // Scheduled once at the boundary, never per frame, and with the
+        // arguments passed directly rather than curried.
+        y.value = withSpring(height, { velocity: e.velocityY }, (finished) => {
+          if (finished) scheduleOnRN(onDismiss);
+        });
+      } else {
+        y.value = withSpring(0, { velocity: e.velocityY });
+      }
+    })
+    // Runs on cancellation as well as on a normal release. onEnd does not fire
+    // when a gesture is cancelled, so without resetting `y` here an interrupted
+    // drag leaves the sheet visibly stranded part-way down.
+    .onFinalize((_e, success) => {
+      start.value = 0;
+      // Only on cancellation — springing here on success would fight the
+      // dismissal animation onEnd just started.
+      if (!success) y.value = withSpring(0);
+    });
+
+  const style = useAnimatedStyle(() => ({
+    // Composited: no layout pass per frame.
+    transform: [{ translateY: y.value }],
+    opacity: reduceMotion ? 1 : 1 - y.value / height / 2,
+  }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View
+        style={style}
+        accessibilityRole="adjustable"
+        accessibilityLabel="Drag to dismiss"
+        // A gesture is not the only route to the action.
+        accessibilityActions={[{ name: 'activate', label: 'Dismiss' }]}
+        onAccessibilityAction={onDismiss}
+      />
+    </GestureDetector>
+  );
+}

--- a/evals/animation/stale-worklet-closure/case.json
+++ b/evals/animation/stale-worklet-closure/case.json
@@ -1,0 +1,107 @@
+{
+  "agent": "rn-animation",
+  "title": "Swipe-to-delete: a gesture pinned by an empty dependency array, plus per-frame JS scheduling",
+  "context": {
+    "reactNative": "0.87",
+    "language": "TypeScript"
+  },
+  "notes": "Six defects. The headline one is a dependency-array bug, not a Reanimated one: the gesture is built inside useMemo with an empty dependency array, so it is created on the first render and never rebuilt, pinning `isDeleting`, `item.id` and `onDelete` to their first values. Without the empty deps this would be fine — Reanimated hooks re-create their worklet when inferred dependencies change, so a captured state value normally refreshes on re-render. That distinction is the point of the case. (2) setIsDeleting is called directly from a gesture callback, which cannot reach the JS thread. (3) runOnJS in onUpdate schedules a JS hop on every frame of the drag. (4) The style animates `left` and `width`, both of which force a layout pass per frame, rather than transform/opacity. (5) No onFinalize, so a cancelled gesture strands the row mid-swipe. (6) No activeOffsetX, so a horizontal swipe fights the vertical list. Tests whether the agent identifies the dependency array as the cause rather than asserting that captured state is always stale.",
+  "expect": [
+    {
+      "name": "identifies the empty dependency array as what pins the captured values",
+      "any": [
+        "dependency array",
+        "usememo",
+        "deps",
+        "empty array",
+        "[]",
+        "pinned",
+        "never rebuilt",
+        "recreat"
+      ]
+    },
+    {
+      "name": "flags calling setState directly from a worklet",
+      "any": [
+        "setisdeleting",
+        "setstate",
+        "runonjs",
+        "scheduleonrn",
+        "js thread",
+        "cross"
+      ]
+    },
+    {
+      "name": "flags per-frame scheduling back to JS in onUpdate",
+      "any": [
+        "every frame",
+        "per frame",
+        "onupdate",
+        "60",
+        "hop",
+        "defeats"
+      ]
+    },
+    {
+      "name": "flags animating layout properties rather than transform",
+      "any": [
+        "transform",
+        "translatex",
+        "layout",
+        "left",
+        "width",
+        "composit"
+      ]
+    },
+    {
+      "name": "notes the missing cancellation path",
+      "any": [
+        "onfinalize",
+        "cancel",
+        "interrupt",
+        "stranded",
+        "mid-swipe"
+      ]
+    },
+    {
+      "name": "raises the scroll-view conflict or activation threshold",
+      "any": [
+        "activeoffset",
+        "failoffset",
+        "scroll",
+        "conflict",
+        "compete"
+      ]
+    }
+  ],
+  "expectSeverity": [
+    {
+      "atLeast": "P1"
+    }
+  ],
+  "forbid": [
+    {
+      "name": "invents a frame rate or millisecond figure",
+      "pattern": "\\b\\d+\\s?(fps|ms|milliseconds)\\b",
+      "unlessPattern": "(?:for example|e\\.?g\\.?|such as|roughly|approximately|measure\\w*)"
+    },
+    {
+      "name": "recommends switching animation library rather than fixing this code",
+      "pattern": "(use|switch to|migrate to|try)\\s+(moti|react-spring|framer|lottie|animated api)",
+      "unlessPattern": "(?:do not|don't|avoid|not)\\s+\\w{0,15}\\s*(?:use|switch|migrate)|\\bnot (?:the fix|necessary|needed)\\b"
+    },
+    {
+      "name": "claims the shared value itself is the problem",
+      "pattern": "(shared value|usesharedvalue)\\s+.{0,30}(is wrong|should not|incorrect|avoid)",
+      "unlessPattern": "(?:is|are)\\s+correct|correctly\\s+\\w+"
+    },
+    {
+      "name": "treats the wrong-item symptom as a list keying bug without the closure",
+      "all": [
+        "key"
+      ],
+      "unlessPattern": "stale|closure|captured|usestate|worklet|snapshot"
+    }
+  ],
+  "elidedHelpers": []
+}

--- a/evals/animation/stale-worklet-closure/case.json
+++ b/evals/animation/stale-worklet-closure/case.json
@@ -97,10 +97,19 @@
     },
     {
       "name": "treats the wrong-item symptom as a list keying bug without the closure",
-      "all": [
-        "key"
+      "any": [
+        "key=",
+        "keyextractor",
+        "key extractor",
+        "list key",
+        "keyed by",
+        "index as a key",
+        "index as the key",
+        "wrong key",
+        "unstable key",
+        "key prop"
       ],
-      "unlessPattern": "stale|closure|captured|usestate|worklet|snapshot"
+      "unlessAnywhere": "stale|closure|captured|usestate|worklet|snapshot|dependency array|usememo|\\bdeps\\b|empty array|\\[\\]|pinned|never rebuilt|recreat"
     }
   ],
   "elidedHelpers": []

--- a/evals/animation/stale-worklet-closure/input.tsx
+++ b/evals/animation/stale-worklet-closure/input.tsx
@@ -1,0 +1,56 @@
+// SwipeableRow.tsx — swipe-to-delete on a list row.
+// The row "sometimes deletes the wrong item" and "stops working after the
+// list updates".
+import React, { useMemo, useState } from 'react';
+import { Text, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+
+const SCREEN_WIDTH = 400;
+
+export function SwipeableRow({ item, onDelete }) {
+  const x = useSharedValue(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Memoised with an empty dependency array, so this gesture object is built
+  // once on the first render and never rebuilt.
+  const pan = useMemo(
+    () => Gesture.Pan()
+    .onUpdate((e) => {
+      x.value = e.translationX;
+      // Reporting progress to the parent on every frame of the drag.
+      runOnJS(onDelete.onProgress)(e.translationX / SCREEN_WIDTH);
+    })
+    .onEnd(() => {
+      // `isDeleting` came from useState, read inside a worklet.
+      if (!isDeleting && x.value > 120) {
+        setIsDeleting(true);
+        runOnJS(onDelete)(item.id);
+        x.value = withSpring(SCREEN_WIDTH);
+      } else {
+        x.value = withSpring(0);
+      }
+    }),
+    [],
+  );
+
+  const style = useAnimatedStyle(() => ({
+    // Animating `left` rather than a transform.
+    left: x.value,
+    width: 300 + x.value,
+  }));
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={style}>
+        <Text>{item.label}</Text>
+        <View />
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/evals/background/load-bearing-sync/case.json
+++ b/evals/background/load-bearing-sync/case.json
@@ -80,7 +80,7 @@
     {
       "name": "recommends a foreground service to make polling reliable",
       "pattern": "foreground service",
-      "unlessPattern": "(?<![\\w-])not\\ appropriate(?![\\w-])|(?<![\\w-])not\\ for(?![\\w-])|rejection\\b|(?<![\\w-])only\\ for(?![\\w-])|(?:user-)?visible\\s+\\w+|\\bvisible to the user|(?<![\\w-])would\\ be\\ misuse(?![\\w-])"
+      "unlessPattern": "\\bnot\\s+\\w{0,15}\\s*(appropriate|for|suitable|the answer|intended)\\b|\\brejection\\b|\\bonly\\s+\\w{0,15}\\s*for\\b|(?:user-)?visible\\s+\\w+|\\bvisible to the user\\b|\\bwould be misuse\\b|\\bmisuse\\b|\\babuse\\b|\\bpolicy\\b"
     },
     {
       "name": "recommends requesting a battery optimisation exemption",

--- a/evals/dependencies/deprecated-storage-swap/case.json
+++ b/evals/dependencies/deprecated-storage-swap/case.json
@@ -79,7 +79,7 @@
       "all": [
         "mmkv"
       ],
-      "unlessPattern": "\\bmigrat\\w+\\b|\\bexisting data\\b|\\bupgrade path\\b|\\bdata already (stored|written|in)\\b"
+      "unlessAnywhere": "\\bmigrat|\\bexisting\\s+(data|users?)\\b|\\bupgrade\\s+path\\b|\\bdata\\s+already\\s+(stored|written|in)\\b|\\bport(ing)?\\s+the\\s+data\\b|\\bdata\\s+loss\\b|\\blose\\s+data\\b|\\bread\\b.{0,20}\\bold\\b.{0,20}(store|storage)"
     },
     {
       "name": "recommends storing auth tokens in plain key-value storage",

--- a/evals/monorepo/duplicate-react/case.json
+++ b/evals/monorepo/duplicate-react/case.json
@@ -80,8 +80,8 @@
     },
     {
       "name": "recommends deleting node_modules as the first step",
-      "pattern": "(rm -rf|delete|remove)\\s+node_modules",
-      "unlessPattern": "\\b(after|once)\\b[^.;,]{0,50}\\b(confirm|identif|diagnos|understand)\\w*|\\b(not|never)\\s+(the\\s+)?first\\b|\\bdestroys\\b|\\bconfirm first\\b|\\bonly (after|once)\\b|\\b(do not|don't|avoid)\\s+\\w{0,10}\\s*(rm -rf|delet|remov)"
+      "pattern": "^[\\s\\S]{0,350}(rm -rf|delete|remove)\\s+node_modules",
+      "unlessPattern": "\\b(after|once)\\b[^.;,]{0,60}\\b(confirm|identif|diagnos|understand)\\w*|\\b(not|never)\\s+(the\\s+)?first\\b|\\bdestroys\\b|\\bconfirm first\\b|\\bonly (after|once)\\b|\\b(do not|don't|avoid)\\s+\\w{0,10}\\s*(rm -rf|delet|remov)"
     },
     {
       "name": "recommends switching package manager as the fix",

--- a/evals/native-modules/clean-turbomodule/case.json
+++ b/evals/native-modules/clean-turbomodule/case.json
@@ -1,14 +1,13 @@
 {
   "agent": "rn-native-modules",
   "title": "Clean TurboModule — generated spec base, bounded executor, every path settles the promise",
-  "context": { "reactNative": "0.87", "language": "Kotlin" },
-
+  "context": {
+    "reactNative": "0.87",
+    "language": "Kotlin"
+  },
   "notes": "The mirror of the legacy-bridge case. Correct throughout: inherits the generated NativeSecureStorageSpec rather than ReactContextBaseJavaModule, uses `override` rather than @ReactMethod, a bounded executor owned by the instance and shut down in invalidate(), every code path resolves or rejects, rejection codes are branchable, the one synchronous method is a trivial in-memory read, no static context, and storage is encrypted. An agent that manufactures threading or lifecycle findings here is pattern-matching on 'native code' rather than reading it.",
-
   "expectMaxFindings": 1,
-
   "expect": [],
-
   "forbid": [
     {
       "name": "claims this uses the removed legacy bridge API",
@@ -16,7 +15,8 @@
     },
     {
       "name": "claims a promise can go unsettled",
-      "pattern": "(never|not|fails to)\\s+\\w*\\s*(resolve|reject|settle)|unsettled|hang"
+      "pattern": "(promise|call|method|it)[^.;,]{0,40}\\b(can|could|may|might|will)\\b[^.;,]{0,25}(hang|never\\s+(resolve|reject|settle)|go\\s+unsettled|be\\s+left\\s+unsettled)|\\b(unsettled|hanging)\\s+promise|\\b(never|fails?\\s+to)\\s+(resolve|reject|settle)s?\\b",
+      "unlessPattern": "\\b(cannot|can't|never\\s+hangs?|does\\s+not|doesn't|no\\s+path|every\\s+path|always\\s+settles?|both\\s+paths?|correctly|is\\s+settled|are\\s+settled|not\\s+possible)\\b|\\bno\\s+(way|risk|chance)\\b"
     },
     {
       "name": "claims cleanup or invalidate is missing",

--- a/evals/observability/proguard-strips-sdk/case.json
+++ b/evals/observability/proguard-strips-sdk/case.json
@@ -88,8 +88,8 @@
     },
     {
       "name": "blames the iOS side when the failure is Android-only",
-      "pattern": "dsym|ios (crash|symbolicat)",
-      "unlessPattern": "(?<![\\w-])ios\\ is\\ fine(?![\\w-])|(?<![\\w-])not\\ the\\ issue(?![\\w-])|(?<![\\w-])already\\ working(?![\\w-])|(?<![\\w-])unaffected(?![\\w-])|(?<![\\w-])by\\ contrast(?![\\w-])"
+      "pattern": "(ios|dsym)[^.;,]{0,50}\\b(is|are|was|were)\\s+(the\\s+)?(problem|issue|cause|culprit|reason|at fault|broken|failing|misconfigured)|\\b(missing|upload)\\s+dsym",
+      "unlessPattern": "\\b(fine|unaffected|not affected|working|works|correct|already)\\b|\\bnot the (problem|issue|cause)\\b|\\bby contrast\\b|\\bandroid[- ]only\\b"
     }
   ]
 }

--- a/evals/onboard/inherited-client-app/case.json
+++ b/evals/onboard/inherited-client-app/case.json
@@ -75,8 +75,8 @@
     },
     {
       "name": "recommends a rewrite or large refactor before understanding",
-      "pattern": "(rewrite|refactor|modernis|moderniz)",
-      "unlessPattern": "(?<![\\w-])do\\ not(?![\\w-])|(?:do not|don't|avoid|never)\\s+\\w{0,15}|resist\\s+\\w+|(?<![\\w-])not\\ yet(?![\\w-])|later(?:\\s+on)?\\b(?![\\w-])|(?<![\\w-])before\\ you\\ understand(?![\\w-])"
+      "pattern": "\\b(should|recommend\\w*|start by|begin by|first|suggest\\w*|propose|plan to|need to|must)\\b[^.;,]{0,40}\\b(rewrite|refactor|modernis|moderniz)\\w*|\\b(rewrite|refactor|modernis|moderniz)\\w*\\s+(the\\s+)?(app|codebase|project)\\s+(first|before)",
+      "unlessPattern": "(?<![\\w-])do\\ not(?![\\w-])|(?:do not|don't|avoid|never)\\s+\\w{0,15}|resist\\s+\\w+|(?<![\\w-])not\\ yet(?![\\w-])|later(?:\\s+on)?\\b(?![\\w-])|(?<![\\w-])before\\ you\\ understand(?![\\w-])|\\bafter\\b|\\bonce you\\b|\\bunderstand\\w*\\s+first\\b"
     },
     {
       "name": "asserts code quality without having read any code",

--- a/evals/permissions/blocked-treated-as-denied/case.json
+++ b/evals/permissions/blocked-treated-as-denied/case.json
@@ -66,8 +66,8 @@
   "forbid": [
     {
       "name": "recommends re-requesting on mount or on every launch",
-      "pattern": "request.{0,30}(on mount|on launch|every time|useEffect)",
-      "unlessPattern": "\\b(do not|don't|avoid|never|not)\\s+\\w{0,20}\\s*(re-?request|request)|\\binstead\\b|\\bonly (when|after|in response)\\b|\\bin response to\\b"
+      "pattern": "\\b(should|must|recommend\\w*|add|call|try|simply|just)\\b[^.;,]{0,40}\\brequest\\w*[^.;,]{0,30}(on mount|on launch|on every launch|every time|in useEffect)",
+      "unlessPattern": "\\b(do not|don't|avoid|never|not)\\b|\\binstead\\b|\\bonly (when|after|in response)\\b|\\bin response to\\b|\\bwill not\\b|\\bno effect\\b|\\bcurrently\\b|\\balready\\b"
     },
     {
       "name": "claims the Info.plist string is missing without having seen it",

--- a/evals/release/missing-sourcemaps/case.json
+++ b/evals/release/missing-sourcemaps/case.json
@@ -1,43 +1,84 @@
 {
   "agent": "rn-release",
   "title": "Release workflow ships source maps as an artifact instead of uploading them, and pins runtimeVersion",
-  "context": { "reactNative": "0.87", "expo": "57" },
-
+  "context": {
+    "reactNative": "0.87",
+    "expo": "57"
+  },
   "notes": "Two defects that only surface when it is too late. The source map is attached to a public build artifact rather than uploaded to a crash reporter — so stack traces stay unreadable AND the map is downloadable by anyone with repository access. Separately, runtimeVersion is pinned to the app version string rather than the fingerprint policy, so any native change ships an OTA that installed binaries cannot run. Straight to production with no staged rollout and no version-tag check compounds both.",
-
   "expect": [
     {
       "name": "flags that source maps are archived rather than uploaded to a crash reporter",
-      "any": ["upload", "sentry", "crash report", "symbolicat", "artifact", "not uploaded"]
+      "any": [
+        "upload",
+        "sentry",
+        "crash report",
+        "symbolicat",
+        "artifact",
+        "not uploaded"
+      ]
     },
     {
       "name": "notes that shipping the map as an artifact is itself a risk",
-      "any": ["exposed", "downloadable", "public", "source code", "reverse", "should not"]
+      "any": [
+        "exposed",
+        "downloadable",
+        "public",
+        "source code",
+        "reverse",
+        "should not"
+      ]
     },
     {
       "name": "flags the manual runtimeVersion instead of the fingerprint policy",
-      "any": ["runtimeversion", "fingerprint", "policy", "manual", "2.4.0"]
+      "any": [
+        "runtimeversion",
+        "fingerprint",
+        "policy",
+        "manual",
+        "2.4.0"
+      ]
     },
     {
       "name": "explains the OTA incompatibility consequence",
-      "any": ["native", "incompatib", "crash on launch", "cannot update", "mismatch"]
+      "any": [
+        "native",
+        "incompatib",
+        "crash on launch",
+        "cannot update",
+        "mismatch"
+      ]
     },
     {
       "name": "flags going straight to production without staged rollout",
-      "any": ["staged", "rollout", "phased", "percentage", "internal track", "canary"]
+      "any": [
+        "staged",
+        "rollout",
+        "phased",
+        "percentage",
+        "internal track",
+        "canary"
+      ]
     },
     {
       "name": "notes the unpinned third-party actions",
-      "any": ["@v4", "pin", "sha", "commit"]
+      "any": [
+        "@v4",
+        "pin",
+        "sha",
+        "commit"
+      ]
     }
   ],
-
-  "expectSeverity": ["P0", "P1"],
-
+  "expectSeverity": [
+    "P0",
+    "P1"
+  ],
   "forbid": [
     {
       "name": "treats attaching the map as an artifact as sufficient",
-      "pattern": "(source ?maps?)\\s+\\w*\\s*(are|is)\\s+\\w*\\s*(handled|covered|uploaded|fine)"
+      "pattern": "(source ?maps?)[^.;,]{0,40}\\b(are|is)\\b[^.;,]{0,25}\\b(handled|covered|fine|sufficient|enough)\\b|\\bupload[- ]artifact\\b[^.;,]{0,50}\\b(sufficient|enough|covers|handles|good)\\b",
+      "unlessPattern": "\\bnot\\b|\\binsufficient\\b|\\bonly\\b|\\bstill (need|must|have to)\\b|\\bto (sentry|bugsnag|crashlytics|datadog)\\b"
     },
     {
       "name": "says a static runtimeVersion is fine",

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -427,7 +427,16 @@ export function undefinedCalls(src, inputName = '') {
   const known = new Set(JS_GLOBALS);
   const add = (n) => { if (/^[\w$]+$/.test(n)) known.add(n); };
 
-  for (const m of src.matchAll(/import\s+(?:type\s+)?\{([^}]*)\}\s+from/g))
+  /**
+   * `import Default, { a, b } from '…'` counts too.
+   *
+   * The pattern used to require `import {` immediately, so the default-plus-named
+   * form — which is `import React, { useState } from 'react'`, the most common
+   * import in any React codebase — contributed none of its named bindings. Every
+   * one of them was then reported as an undefined call, and the fixture looked
+   * broken when the parser was.
+   */
+  for (const m of src.matchAll(/import\s+(?:type\s+)?(?:[\w$]+\s*,\s*)?\{([^}]*)\}\s+from/g))
     for (const part of m[1].split(',')) add(part.trim().split(/\s+as\s+/).pop().replace(/^type\s+/, '').trim());
   for (const m of src.matchAll(/import\s+(?:type\s+)?([\w$]+)\s*(?:,|from)/g)) add(m[1]);
   for (const m of src.matchAll(/(?:function|class)\s+([\w$]+)/g)) add(m[1]);

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -178,6 +178,62 @@ export function isQuestionCase(tc, agent) {
   return agent?.mode === 'interactive' || /\.(md|txt)$/.test(tc.inputName);
 }
 
+/**
+ * The text a case is actually scored against.
+ *
+ * `scoreOutput` used to receive the model's **raw** response, which for a
+ * structured case is a fenced JSON document. That put the envelope inside the
+ * haystack, and both directions were wrong:
+ *
+ * - False violations. `state/server-state-in-store` reported "leads with the
+ *   server-state split" with the evidence being a literal ```json blob — the
+ *   pattern had matched JSON syntax and key names, not advice.
+ * - False passes. An `expect` term like "file" or "line" is present in every
+ *   structured response ever emitted, because those are field names. The case
+ *   would score a match without the model having said anything.
+ *
+ * Scoring the human-readable fields — title, why, fix, plus the summary — keeps
+ * the assertion pointed at what the agent actually told the user. Ordering is
+ * preserved so "leads with X" rules can still reason about which finding came
+ * first. Prose/question cases have no envelope, so they keep the raw text.
+ */
+/**
+ * Why did this case fail?
+ *
+ * Every failure used to be reported as "missed expected findings", which was
+ * wrong for two whole categories. `state/server-state-in-store` was listed at
+ * **6/6** — it matched every expectation and failed on a forbid rule, so the
+ * label sent you hunting for a finding that was not missing. An errored case
+ * was listed as `0/0`, which reads as "matched nothing" rather than "never
+ * produced a response".
+ *
+ * Order matters: an error means nothing else was scored, and a complete answer
+ * that gives forbidden advice is a different defect from an incomplete one.
+ */
+export function classifyFailure(r) {
+  if (!r || r.pass) return null;
+  if (r.error) return 'errored';
+  const violated = Boolean(r.score?.violations?.length);
+  const complete =
+    (r.score?.expectTotal ?? 0) > 0 && r.score.expectPassed === r.score.expectTotal;
+  if (violated && (complete || (r.score?.expectTotal ?? 0) === 0)) return 'violation';
+  if (violated) return 'violation-and-missed';
+  return 'missed';
+}
+
+export function scannableText(raw, parsed, isQuestion) {
+  if (isQuestion) return raw;
+  const findings = parsed?.findings ?? [];
+  if (!findings.length) return parsed?.summary ? String(parsed.summary) : '';
+  const parts = findings.map((f) =>
+    [f.severity, f.title, f.why, f.fix, f.detail]
+      .filter((v) => typeof v === 'string' && v.trim())
+      .join('. '),
+  );
+  if (parsed.summary) parts.push(String(parsed.summary));
+  return parts.join('\n\n');
+}
+
 export function scoreOutput(text, def) {
   const haystack = text.toLowerCase();
   const expected = [];
@@ -193,11 +249,13 @@ export function scoreOutput(text, def) {
     let triggered = false;
     let evidence = null;
 
+    let matchEnd = -1;
     if (f.pattern) {
       const m = haystack.match(new RegExp(f.pattern, 'i'));
       if (m) {
         triggered = true;
         evidence = m[0];
+        matchEnd = m.index + m[0].length;
       }
     }
 
@@ -235,7 +293,36 @@ export function scoreOutput(text, def) {
     if (triggered && evidence && f.unlessPattern) {
       const ev = String(evidence).toLowerCase();
       const clauses = splitClauses(haystack);
-      const at = clauses.findIndex((part) => part.includes(ev));
+
+      /**
+       * Locate the clause by where the match *ended*, not by searching for the
+       * evidence text.
+       *
+       * A pattern anchored to the start of the response — `^[\s\S]{0,350}…`,
+       * which is how the suite expresses "as the first step" — matches a span
+       * covering many clauses. `clauses.findIndex(c => c.includes(evidence))`
+       * then finds nothing, `clause` falls back to '', and the exception can
+       * never match: a correct answer was reported as a violation purely
+       * because of how the rule was anchored.
+       *
+       * The forbidden advice is where the match *ends*; everything before it is
+       * positional context. Offsets also disambiguate a phrase that appears
+       * more than once, which the substring search silently got wrong.
+       */
+      let at = -1;
+      if (matchEnd >= 0) {
+        let cursor = 0;
+        for (let i = 0; i < clauses.length; i++) {
+          const found = haystack.indexOf(clauses[i], cursor);
+          if (found === -1) continue;
+          cursor = found + clauses[i].length;
+          if (matchEnd <= cursor) {
+            at = i;
+            break;
+          }
+        }
+      }
+      if (at === -1) at = clauses.findIndex((part) => part.includes(ev));
 
       /**
        * The evidence clause, plus a comma-joined clause immediately before it.
@@ -290,6 +377,28 @@ export function scoreOutput(text, def) {
        * how the old behaviour comes back.
        */
       triggered = conceded || !new RegExp(f.unlessPattern, 'i').test(clause);
+    }
+
+    /**
+     * `unlessAnywhere` — a document-scoped exception, for rules whose claim is
+     * itself document-scoped.
+     *
+     * Clause scope is the right default and was hard-won, but it cannot express
+     * every rule. Two rules here assert an *absence across the whole answer*:
+     * "recommends the swap without mentioning migration **at all**" and
+     * "presents the migration **as free**". Their trigger is a bare product
+     * name, so they fire on the mention and then look for their exception in
+     * the same clause — which is the one place a discussion of migration cost
+     * will almost never be. The rule name promised one scope and the mechanism
+     * enforced another, so both reported violations against answers that did
+     * discuss the cost, a sentence later.
+     *
+     * Deliberately a separate field rather than a widening of `unlessPattern`:
+     * a rule author has to choose the scope explicitly, and the narrow one
+     * stays the default.
+     */
+    if (triggered && f.unlessAnywhere && new RegExp(f.unlessAnywhere, 'i').test(haystack)) {
+      triggered = false;
     }
 
     forbidden.push({ name: f.name, violated: triggered, evidence });
@@ -415,15 +524,73 @@ const JS_GLOBALS = new Set([
   'Object','Array','String','Number','Boolean','Date','Math','Error','RegExp','Map','Set','Symbol',
   'require','process','parseInt','parseFloat','isNaN','encodeURIComponent','decodeURIComponent',
   'Buffer','structuredClone','queueMicrotask','AbortController','URL','TextEncoder','alert',
+  'Intl','globalThis','WeakMap','WeakSet','Proxy','Reflect','BigInt','performance',
   'useState','useEffect','useCallback','useMemo','useRef','useLayoutEffect','useContext','useReducer',
   'describe','it','test','expect','beforeEach','afterEach','beforeAll','afterAll','jest',
   'async','else','do','try','finally','yield','delete','void','in','of','if','for','while',
   'switch','catch','return','function','typeof','await','new','super','import',
 ]);
 
+/**
+ * Strip comments and string/template literals before scanning.
+ *
+ * The scan looks for call syntax, and English prose is full of things that look
+ * like it. "…the sheet is gone. Cancelling on unmount (…" parses as
+ * `gone.Cancelling(`; a comment mentioning `worklet.` before a parenthesis does
+ * the same. Nine of the fourteen findings on the first run of the member-call
+ * scan were sentences in comments.
+ *
+ * Replacing with spaces rather than deleting keeps offsets stable, so anything
+ * reported still lines up with the source.
+ */
+export function stripCommentsAndStrings(src) {
+  let out = '';
+  let i = 0;
+  const blank = (n) => ' '.repeat(n);
+
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+
+    if (two === '//') {
+      const end = src.indexOf('\n', i);
+      const stop = end === -1 ? src.length : end;
+      out += blank(stop - i);
+      i = stop;
+      continue;
+    }
+    if (two === '/*') {
+      const end = src.indexOf('*/', i + 2);
+      const stop = end === -1 ? src.length : end + 2;
+      out += src.slice(i, stop).replace(/[^\n]/g, ' ');
+      i = stop;
+      continue;
+    }
+
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === '\\') { j += 2; continue; }
+        if (src[j] === ch) { j += 1; break; }
+        j += 1;
+      }
+      out += src.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+      continue;
+    }
+
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
 export function undefinedCalls(src, inputName = '') {
   if (!/\.(ts|tsx|js|jsx)$/.test(inputName)) return [];
 
+  // Bindings are collected from the original (imports are unaffected by
+  // stripping), but call sites are read from code only.
+  const code = stripCommentsAndStrings(src);
   const known = new Set(JS_GLOBALS);
   const add = (n) => { if (/^[\w$]+$/.test(n)) known.add(n); };
 
@@ -439,6 +606,23 @@ export function undefinedCalls(src, inputName = '') {
   for (const m of src.matchAll(/import\s+(?:type\s+)?(?:[\w$]+\s*,\s*)?\{([^}]*)\}\s+from/g))
     for (const part of m[1].split(',')) add(part.trim().split(/\s+as\s+/).pop().replace(/^type\s+/, '').trim());
   for (const m of src.matchAll(/import\s+(?:type\s+)?([\w$]+)\s*(?:,|from)/g)) add(m[1]);
+  /**
+   * Namespace imports — `import * as SecureStore from 'expo-secure-store'`.
+   *
+   * Not collected at all until the member-call scan started checking receivers,
+   * at which point every namespace import in the suite was reported as
+   * undefined. The binding is the alias after `as`.
+   */
+  for (const m of src.matchAll(/import\s+\*\s+as\s+([\w$]+)\s+from/g)) add(m[1]);
+  /**
+   * Destructured callback parameters — `({ url }) => …`.
+   *
+   * The existing parameter scan strips braces from the whole parameter list and
+   * keeps what is left, which works for `(a, b)` but throws away the names in
+   * `({ url })`. Those are bindings like any other.
+   */
+  for (const m of src.matchAll(/\(\s*\{([^}]*)\}\s*(?::[^)]*)?\)\s*=>/g))
+    for (const part of m[1].split(',')) add(part.trim().split(':').pop().trim().replace(/=.*$/, '').trim());
   for (const m of src.matchAll(/(?:function|class)\s+([\w$]+)/g)) add(m[1]);
   for (const m of src.matchAll(/(?:const|let|var)\s+([\w$]+)\s*[=:]/g)) add(m[1]);
   for (const m of src.matchAll(/(?:const|let|var)\s*\{([^}]*)\}\s*=/g))
@@ -450,8 +634,31 @@ export function undefinedCalls(src, inputName = '') {
     for (const part of m[1].split(',')) add(part.trim().split(':')[0].replace(/[{}[\].]/g, '').trim());
 
   const missing = new Set();
-  for (const m of src.matchAll(/(^|[^.\w$])\b([a-z_$][\w$]*)\s*\(/gm))
+  for (const m of code.matchAll(/(^|[^.\w$])\b([a-z_$][\w$]*)\s*\(/gm))
     if (!known.has(m[2])) missing.add(m[2]);
+
+  /**
+   * Calls through an undefined namespace object — `SecureStore.deleteItemAsync()`.
+   *
+   * The scan above deliberately skips anything preceded by a dot, so that
+   * `foo.bar()` is not reported as a missing `bar`. The consequence was that the
+   * *receiver* went unchecked entirely: `evals/state/clean-auth-store` called
+   * `SecureStore.deleteItemAsync` with no import of SecureStore, and the fixture
+   * validator passed it. A clean case is an assertion that there is nothing to
+   * report, so a fixture that does not compile makes the case fail against every
+   * model that reads it correctly — the suite was penalising the right answer.
+   *
+   * Capitalised roots are included here, unlike the call scan: a namespace
+   * import is conventionally capitalised, which is exactly the case being
+   * missed. `this`/`super` are receivers, not bindings, and a chained call
+   * (`foo().bar()`) has no identifier root to check.
+   */
+  for (const m of code.matchAll(/(^|[^.\w$])\b([A-Za-z_$][\w$]*)\s*\.\s*[\w$]+\s*\(/gm)) {
+    const root = m[2];
+    if (root === 'this' || root === 'super') continue;
+    if (!known.has(root)) missing.add(root);
+  }
+
   return [...missing];
 }
 
@@ -480,7 +687,7 @@ export function checkSeverity(findings, def) {
  * Validation — structural checks, no API key, no spend
  * ------------------------------------------------------------------ */
 
-function validate(cases, agents) {
+export function validate(cases, agents) {
   const agentIds = new Set(agents.map((a) => a.id));
   const problems = [];
 
@@ -553,6 +760,42 @@ function validate(cases, agents) {
           );
         }
       }
+      if (f.unlessAnywhere !== undefined) {
+        if (typeof f.unlessAnywhere !== 'string' || !f.unlessAnywhere.trim()) {
+          problems.push(`${id}: forbid "${f.name}" has an empty unlessAnywhere`);
+        } else {
+          try {
+            new RegExp(f.unlessAnywhere, 'i');
+          } catch (err) {
+            problems.push(
+              `${id}: forbid "${f.name}" has an invalid unlessAnywhere — ${err.message}`,
+            );
+          }
+        }
+        /**
+         * Document scope is a real widening, so it must be earned.
+         *
+         * A rule that already states a precise pattern does not need to search
+         * the whole answer for its exception — that combination is how you get
+         * back to "a legitimate word anywhere excuses everything", which is the
+         * exact failure `unless` was removed for. It is available only to the
+         * bare-term rules whose claim is genuinely about the whole response.
+         */
+        if (f.pattern) {
+          problems.push(
+            `${id}: forbid "${f.name}" combines a specific "pattern" with the ` +
+              `document-scoped "unlessAnywhere". Use "unlessPattern" (clause-scoped) ` +
+              `instead — whole-response exceptions are for bare-term rules only.`,
+          );
+        }
+        if (f.unlessPattern) {
+          problems.push(
+            `${id}: forbid "${f.name}" sets both unlessPattern and unlessAnywhere — ` +
+              `pick one scope.`,
+          );
+        }
+      }
+
       /**
        * `unless` is gone, and reintroducing it is an error.
        *
@@ -679,11 +922,41 @@ async function main() {
   const baseUrl = args['base-url'] ?? process.env.OPENAI_BASE_URL;
   if (baseUrl) console.log(c.dim(`  endpoint: ${baseUrl}\n`));
 
+  /**
+   * Deterministic sampling for local endpoints.
+   *
+   * Nothing set temperature, so runs used the provider default — 0.8 on Ollama.
+   * Two sweeps over identical inputs gave 3/16 and 8/16 clean-case failures,
+   * and that spread swamped any signal a change to a rule or an agent could
+   * produce: you cannot tell a fix from noise when the noise is that large.
+   *
+   * Local only, by default. OpenAI's reasoning models reject a temperature
+   * other than 1, so forcing 0 everywhere would break hosted runs — and a
+   * hosted run is the one place the default is worth keeping, because it is the
+   * configuration real users get. `--temperature` and `--seed` override, and
+   * `--temperature default` sends none at all.
+   */
+  const isLocalEndpoint = /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/.test(
+    baseUrl ?? '',
+  );
+  let temperature;
+  if (args.temperature === 'default') temperature = undefined;
+  else if (args.temperature !== undefined) temperature = Number(args.temperature);
+  else if (isLocalEndpoint) temperature = 0;
+
+  const seed = args.seed !== undefined ? Number(args.seed) : isLocalEndpoint ? 7 : undefined;
+
+  if (temperature !== undefined) {
+    console.log(c.dim(`  sampling: temperature ${temperature}${seed === undefined ? '' : `, seed ${seed}`}\n`));
+  }
+
   const llm = new LLM({
     provider,
     apiKey,
     model,
     baseUrl,
+    temperature,
+    seed,
     budgetUsd: Number(args.budget ?? 5),
   });
   const results = [];
@@ -716,10 +989,19 @@ async function main() {
         id: r.tc.id,
         agent: r.tc.def.agent,
         clean: r.tc.def.expectMaxFindings !== undefined,
+        maxFindings: r.tc.def.expectMaxFindings ?? null,
         pass: r.pass ?? false,
         expectPassed: r.score?.expectPassed ?? 0,
         expectTotal: r.score?.expectTotal ?? 0,
-        violations: r.score?.violations?.map((v) => v.name) ?? [],
+        /**
+         * Name *and* evidence. Storing only the name meant a reported violation
+         * could not be triaged after the run: "matched \"ios crash\"" tells you
+         * whether the rule caught real advice or fired on the model quoting the
+         * symptom, and that distinction decides whether to fix the agent or the
+         * rule. Objects, not strings — restore below accepts both shapes.
+         */
+        violations:
+          r.score?.violations?.map((v) => ({ name: v.name, evidence: v.evidence ?? null })) ?? [],
         severity: r.sev?.ok ?? null,
         noise: r.cap?.ok ?? null,
         error: r.error ?? null,
@@ -817,7 +1099,8 @@ async function main() {
         continue;
       }
     }
-    const score = scoreOutput(raw, tc.def);
+    // Scored on what the agent said, not on the JSON it said it in.
+    const score = scoreOutput(scannableText(raw, parsed, isQuestion), tc.def);
     const sev = isQuestion ? { ok: true } : checkSeverity(parsed.findings, tc.def);
     const cap = isQuestion ? { ok: true } : checkMaxFindings(parsed.findings, tc.def);
     const pass = score.pass && sev.ok && cap.ok;
@@ -865,12 +1148,24 @@ async function main() {
    * reporting below expects rather than being special-cased at each use.
    */
   const restored = previous.map((row) => ({
-    tc: { id: row.id, def: { agent: row.agent, ...(row.clean ? { expectMaxFindings: 0 } : {}) } },
+    tc: {
+      id: row.id,
+      def: {
+        agent: row.agent,
+        // The real cap, not 0. Flattening every restored clean case to
+        // `expectMaxFindings: 0` made `--resume` describe a case that allows one
+        // finding as one that allows none, so a resumed summary disagreed with
+        // the run that produced it.
+        ...(row.clean ? { expectMaxFindings: row.maxFindings ?? 0 } : {}),
+      },
+    },
     pass: row.pass,
     score: {
       expectPassed: row.expectPassed ?? 0,
       expectTotal: row.expectTotal ?? 0,
-      violations: (row.violations ?? []).map((name) => ({ name })),
+      violations: (row.violations ?? []).map((v) =>
+        typeof v === 'string' ? { name: v, evidence: null } : v,
+      ),
     },
     sev: { ok: row.severity },
     cap: { ok: row.noise },
@@ -909,27 +1204,82 @@ async function main() {
   if (violated) {
     console.log(c.red(`  ${violated} forbidden-advice violation(s)`));
     for (const r of all.filter((x) => x.score?.violations.length)) {
-      for (const v of r.score.violations) console.log(c.red(`    ${r.tc.id} — ${v.name}`));
+      for (const v of r.score.violations) {
+        // Show what matched. Without it the only way to tell a real violation
+        // from a rule firing on the model quoting the symptom is to re-run.
+        const ev = v.evidence
+          ? c.dim(`  matched "${String(v.evidence).replace(/\s+/g, ' ').trim().slice(0, 70)}"`)
+          : '';
+        console.log(c.red(`    ${r.tc.id} — ${v.name}`) + ev);
+      }
     }
   }
 
   if (cleanFailed.length) {
-    console.log(c.red(`\n  ${cleanFailed.length}/${cleanResults.length} clean case(s) failed — the model reported problems in correct code`));
+    console.log(c.red(`\n  ${cleanFailed.length}/${cleanResults.length} clean case(s) failed`));
     for (const r of cleanFailed) {
-      console.log(c.red(`    ${r.tc.id}`) + c.dim(`  ${r.cap?.note ?? r.sev?.note ?? ''}`));
+      /**
+       * Print the reason this case actually failed.
+       *
+       * This used to print `cap.note` unconditionally, so a clean case that
+       * failed on a *forbid violation* reported "expected at most 1 finding(s),
+       * got 1" — a sentence that contradicts itself and hides the real cause.
+       * The cap note is only meaningful when the cap is what failed.
+       */
+      const why = [];
+      if (r.error) why.push(`errored: ${r.error}`);
+      if (r.score?.violations?.length) {
+        why.push(`forbidden advice: ${r.score.violations.map((v) => v.name).join('; ')}`);
+      }
+      if (r.cap && !r.cap.ok && r.cap.note) why.push(r.cap.note);
+      if (r.sev && !r.sev.ok && r.sev.note) why.push(r.sev.note);
+      console.log(c.red(`    ${r.tc.id}`) + c.dim(`  ${why.join('  ·  ') || 'failed'}`));
     }
   } else if (cleanResults.length) {
     console.log(c.green(`  all ${cleanResults.length} clean case(s) passed — no invented findings`));
   }
 
-  if (dirtyFailed.length) {
+  /**
+   * Partition by what actually went wrong.
+   *
+   * Everything that failed used to land under "missed expected findings",
+   * including `state/server-state-in-store` at **6/6** — it matched every
+   * expectation and failed on a forbid rule. Listing it as a miss sends you
+   * looking for an absent finding that is not absent. An errored case appeared
+   * here too, as a meaningless `0/0`.
+   */
+  const dirtyErrored = dirtyFailed.filter((r) => classifyFailure(r) === 'errored');
+  const dirtyViolated = dirtyFailed.filter((r) => classifyFailure(r) === 'violation');
+  const dirtyMissed = dirtyFailed.filter((r) =>
+    ['missed', 'violation-and-missed'].includes(classifyFailure(r)),
+  );
+
+  if (dirtyErrored.length) {
+    console.log(c.red(`\n  ${dirtyErrored.length} case(s) errored — no usable response, so nothing was scored`));
+    for (const r of dirtyErrored) console.log(c.red(`    ${r.tc.id}`) + c.dim(`  ${r.error}`));
+  }
+
+  if (dirtyViolated.length) {
     console.log(
-      c.yellow(`\n  ${dirtyFailed.length}/${dirtyResults.length} case(s) missed expected findings`) +
+      c.red(`\n  ${dirtyViolated.length} case(s) matched every expectation but gave forbidden advice`) +
+        c.dim(' — not a capability gap; the answer was complete and wrong'),
+    );
+    for (const r of dirtyViolated) {
+      console.log(
+        c.red(`    ${r.tc.id}  ${r.score.expectPassed}/${r.score.expectTotal}`) +
+          c.dim(`  ${r.score.violations.map((v) => v.name).join('; ')}`),
+      );
+    }
+  }
+
+  if (dirtyMissed.length) {
+    console.log(
+      c.yellow(`\n  ${dirtyMissed.length}/${dirtyResults.length} case(s) missed expected findings`) +
         c.dim(' — ambiguous on a small model; check whether the finding is genuinely absent'),
     );
     // Sorted worst-first: a case matching 1 of 8 is a different problem from one
     // matching 7 of 8, and the flat list gave no way to tell them apart.
-    for (const r of [...dirtyFailed].sort(
+    for (const r of [...dirtyMissed].sort(
       (a, b) => (a.score?.expectPassed ?? 0) / Math.max(1, a.score?.expectTotal ?? 1)
         - (b.score?.expectPassed ?? 0) / Math.max(1, b.score?.expectTotal ?? 1),
     )) {

--- a/evals/state/clean-auth-store/input.ts
+++ b/evals/state/clean-auth-store/input.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
 

--- a/evals/state/server-state-in-store/case.json
+++ b/evals/state/server-state-in-store/case.json
@@ -93,7 +93,7 @@
       "all": [
         "tanstack"
       ],
-      "unlessPattern": "\\b(cost|effort|work|touches|every screen|incremental|not free|takes time|migration cost)\\b"
+      "unlessAnywhere": "\\b(cost|effort|work|touches|every screen|incremental|not free|takes time|migration cost|non-trivial|rewrite)\\b"
     }
   ]
 }

--- a/knowledge.json
+++ b/knowledge.json
@@ -1,57 +1,62 @@
 {
   "$comment": "Freshness metadata for the React Native knowledge in agents/ and shared/. This is the single source of truth for 'what have we actually checked?'. The scheduled freshness workflow compares these against the live npm registry and opens an issue when they fall behind. Update `last_verified` only after genuinely reviewing the affected references — bumping the date without reading is worse than leaving it stale, because it launders an unchecked claim as a verified one.",
-
   "last_verified": "2026-08-12",
-
   "reactNative": {
     "verified_through": "0.87",
     "min_supported": "0.76",
     "notes": "New Architecture default since 0.76. Legacy bridge removed in 0.82. Hermes V1 default since 0.84. Advice for <0.76 is treated as legacy and must be called out explicitly rather than assumed."
   },
-
   "expo": {
     "verified_through": "57",
     "min_supported": "54",
     "notes": "SDK 57 released 2026-06-30. Roughly three SDKs per year."
   },
-
   "react": {
     "verified_through": "19.2",
     "notes": "Concurrent features, React Compiler, and `use()` are all in scope."
   },
-
   "libraries": {
     "$comment": "Third-party libraries whose API the agents quote concretely. Tracked separately from the platform because they move on their own schedule, and because payments guidance went stale across three review rounds while the React Native version above was current.",
     "react-native-iap": {
       "package": "react-native-iap",
       "verified_through": "14.7",
       "verified_on": "2026-08-24",
-      "used_by": ["rn-payments"],
+      "used_by": [
+        "rn-payments"
+      ],
       "notes": "v14 is a hard break, not a deprecation: getProducts, getSubscriptions, requestSubscription, getPurchaseHistory, clearProductsIOS, flushFailedPurchasesCachedAsPendingAndroid and setup were removed. StoreKit 2 (iOS 15+), Play Billing 7+, RN 0.71+. Error codes moved to the unified ErrorCode enum, so the old 'E_USER_CANCELLED' string silently stops matching. purchase-flow.md carries the full v13→v14 table."
     }
   },
-
+  "reanimated": {
+    "$comment": "Reanimated 4 is a larger break than its 'API is compatible' framing suggests. Verified against the official migration guide and glossary; the agent quotes these APIs directly.",
+    "verified_on": "2026-08-27",
+    "verified_through": "4.x",
+    "source": "https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x",
+    "used_by": [
+      "rn-animation"
+    ],
+    "notes": "New Architecture ONLY — Paper dropped. There is NO single React Native floor: support is a moving window per Reanimated minor, and newer minors DROP older RN versions. As of 2026-08-27 the table spans RN 0.78-0.87; 4.7.x supports 0.85-0.87 only (not 0.78), 4.1.x supports 0.78-0.82 (not 0.83+). react-native-worklets has its own matrix: 4.7.x needs worklets 0.13.x. Always read the official compatibility table, or compatibility.json inside the installed package — the table assumes the latest patch of each minor. Worklets moved to a separate react-native-worklets package; Babel plugin renamed react-native-reanimated/plugin -> react-native-worklets/plugin. Threading functions renamed AND un-curried: runOnJS -> scheduleOnRN(fn, args), runOnUI -> scheduleOnUI, executeOnUIRuntimeSync -> runOnUISync, runOnRuntime -> scheduleOnRuntime, makeShareableCloneRecursive -> createSerializable. REMOVED: useAnimatedGestureHandler, useWorkletCallback (gorhom/bottom-sheet needs >=5.1.8), combineTransition, react-native-v8 support. withSpring: rest thresholds -> single relative energyThreshold; duration is PERCEPTUAL (actual 1.5x); defaults changed (Reanimated3DefaultSpringConfig). useScrollViewOffset -> useScrollOffset. addWhitelisted*Props are no-ops. useAnimatedKeyboard deprecated. Shared Element Transitions experimental. New in 4: CSS animations/transitions. THREAD MODEL: the 'worklet' directive only makes a function serializable — the scheduling API decides placement, and useAnimatedStyle's callback runs on the JS thread first and then the UI thread (hence global._WORKLET). Gesture callbacks can be configured to run on JS. Captured props/state are NOT frozen forever: the hooks re-create their worklet when inferred dependencies change, so React-driven values refresh. Shared values are required for changes driven from the UI thread BETWEEN renders. Real staleness comes from a worklet pinned by an empty/incomplete dependency array."
+  },
   "yarnBerry": {
     "$comment": "Recorded because 'Yarn workspaces = hoisted' was true of Classic and wrong for Berry, and the monorepo agent stated it flatly.",
     "verified_on": "2026-08-24",
     "source": "https://yarnpkg.com/configuration/yarnrc#nodeLinker",
     "notes": "Yarn 2+ has three nodeLinker modes: 'pnp' (single .pnp loader, no node_modules), 'pnpm' (node_modules of symlinks/hardlinks into a content-addressable store), and 'node-modules' (regular hoisted layout as in Classic/npm). React Native requires node-modules — Metro, autolinking, Gradle and CocoaPods all need real directories and none support PnP. nmHoistingLimits (none | workspaces | dependencies) still restricts hoisting under node-modules and can reintroduce duplicate copies. Do not state a Berry default; it has been contested between releases — read the project's .yarnrc.yml instead.",
-    "used_by": ["rn-monorepo"]
+    "used_by": [
+      "rn-monorepo"
+    ]
   },
-
   "appleBackground": {
     "$comment": "Not an npm package, so the freshness job cannot check it. Recorded so the claim carries a date.",
     "verified_on": "2026-08-24",
     "source": "https://developer.apple.com/documentation/foundation/urlsessionconfiguration/background(withidentifier:)",
     "notes": "A background URLSession transfer continues when the app is suspended or terminated BY THE SYSTEM, and the system relaunches the app so it can collect results using the same identifier. User force-quit from the app switcher is different: the system cancels all of that session's background transfers and does not automatically relaunch the app — the user must open it before transfers resume. Guidance must distinguish the two; 'survives being killed' unqualified is wrong."
   },
-
   "applePayments": {
     "$comment": "Not an npm package, so the freshness job cannot check it — it is recorded here so the claim has a date attached rather than being implicitly current.",
     "verified_on": "2026-08-24",
     "notes": "verifyReceipt deprecated 2023-06-05. Still functional, no end-of-life date announced, receives no new features. Apple directs new work to the App Store Server API, to verifying StoreKit 2 signed JWS via the App Store Server Library, or to App Store Server Notifications V2. The 21007 production-then-sandbox retry is specific to verifyReceipt: the App Store Server API selects environment by base URL (api.storekit.itunes.apple.com vs api.storekit-sandbox.itunes.apple.com) and returns 401 for a cross-environment transaction id."
   },
-
   "policy": {
     "review_window_days": 90,
     "on_new_minor": "Open a maintenance issue listing references that mention version-specific behaviour.",

--- a/mcp-server/routing.mjs
+++ b/mcp-server/routing.mjs
@@ -16,6 +16,30 @@
  * `weak` terms only break ties.
  */
 export const SIGNALS = {
+  'rn-animation': {
+    strong: [
+      'reanimated', 'worklet', 'worklets', 'shared value', 'useSharedValue',
+      'useAnimatedStyle', 'useAnimatedProps', 'useDerivedValue', 'useAnimatedReaction',
+      'runOnJS', 'runOnUI', 'scheduleOnRN', 'scheduleOnUI', 'react-native-worklets',
+      'useAnimatedGestureHandler', 'GestureDetector', 'gesture handler',
+      'withTiming', 'withSpring', 'withDecay', 'withSequence', 'withRepeat',
+      'layout animation', 'entering animation', 'exiting animation',
+      'swipe to delete', 'pinch to zoom', 'drag gesture', 'pan gesture',
+      // The legacy APIs route here too. An app still on core `Animated` or
+      // `LayoutAnimation` has the same authoring questions, and asking about
+      // them should not fall through to rn-performance.
+      'Animated.timing', 'Animated.spring', 'Animated.sequence',
+      'LayoutAnimation', 'useNativeDriver', 'PanResponder',
+    ],
+    medium: [
+      'animate', 'animating', 'animation', 'animated', 'gesture', 'gestures',
+      'swipe', 'swiping', 'drag', 'dragging', 'pinch', 'transition',
+      'interpolate', 'spring', 'easing', 'fade in', 'fade out', 'slide in',
+      'stale closure', 'ui thread', 'js thread',
+    ],
+    weak: ['motion', 'smooth', 'tween', 'keyframe', 'parallax'],
+  },
+
   'rn-performance': {
     strong: [
       // NOT 'profil*': 'profile' is a user-profile screen far more often than a

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maheshwarimrinal/react-native-agents",
-  "version": "1.3.1",
-  "description": "24 expert React Native agents — upgrades and New Architecture migration, debugging, performance, security, offline sync, navigation and deep linking, push notifications, permissions, iOS/Android parity, state management, accessibility, testing, native modules, observability, release, store submission, dependency choices, codebase onboarding, in-app purchases, background execution, and monorepo setup — plus a deterministic bundle-size analyzer. Portable across Claude Code, Cursor, Windsurf, Copilot, Codex, MCP clients, and GitHub Actions.",
+  "version": "1.4.0",
+  "description": "25 expert React Native agents — upgrades and New Architecture migration, debugging, animation and gestures, performance, security, offline sync, navigation and deep linking, push notifications, permissions, iOS/Android parity, state management, accessibility, testing, native modules, observability, release, store submission, dependency choices, codebase onboarding, in-app purchases, background execution, and monorepo setup — plus a deterministic bundle-size analyzer. Portable across Claude Code, Cursor, Windsurf, Copilot, Codex, MCP clients, and GitHub Actions.",
   "type": "module",
   "bin": {
     "react-native-agents": "./scripts/cli.mjs",
@@ -86,7 +86,11 @@
     "headless-js",
     "monorepo",
     "metro",
-    "turborepo"
+    "turborepo",
+    "reanimated",
+    "gestures",
+    "worklets",
+    "animation"
   ],
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "node scripts/build.mjs",
     "check": "node scripts/build.mjs --check",
     "test": "node scripts/test.mjs && node action/test.mjs && node evals/run.mjs --validate",
+    "audit:local": "node scripts/audit-local.mjs",
     "test:agents": "node scripts/test.mjs",
     "test:action": "node action/test.mjs",
     "install-agents": "node scripts/cli.mjs install",

--- a/scripts/audit-local.mjs
+++ b/scripts/audit-local.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Run the audit against a locally-hosted model (Ollama, LM Studio, llama.cpp —
+ * anything exposing an OpenAI-compatible `/v1/chat/completions`).
+ *
+ * The audit already speaks OpenAI's wire format, so this script adds no
+ * capability. What it adds is the preflight nobody remembers to do by hand:
+ *
+ *   1. Is the server actually up? (Otherwise you get a bare ECONNREFUSED
+ *      halfway through the first agent, after routing has already printed.)
+ *   2. Is the model pulled? A typo'd tag reaches Ollama and comes back as a
+ *      404 per agent, which reads like a code failure rather than a typo.
+ *   3. **Is the context window big enough?** This is the one that matters.
+ *      Ollama defaults `num_ctx` to 4096 for most models regardless of what the
+ *      model supports. The audit sends whole changed files, so a real diff
+ *      overflows that instantly — and Ollama does not error, it silently drops
+ *      the front of the prompt. That front is the agent instructions. You get a
+ *      confident, well-formatted, entirely ungrounded review, and a green
+ *      "✓ Passed" that means nothing. This script measures the prompt and
+ *      refuses to run when it will not fit.
+ *
+ * Usage:
+ *   node scripts/audit-local.mjs                      # uncommitted changes
+ *   node scripts/audit-local.mjs --base main          # this branch vs main
+ *   node scripts/audit-local.mjs --diff-file pr.diff  # a saved diff
+ *   node scripts/audit-local.mjs --model qwen2.5-coder:32b
+ *   node scripts/audit-local.mjs --repo ~/my-app --base main
+ */
+
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const args = {};
+for (let i = 2; i < process.argv.length; i++) {
+  const a = process.argv[i];
+  if (!a.startsWith('--')) continue;
+  const eq = a.indexOf('=');
+  if (eq !== -1) args[a.slice(2, eq)] = a.slice(eq + 1);
+  else if (process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) args[a.slice(2)] = process.argv[++i];
+  else args[a.slice(2)] = 'true';
+}
+
+const BASE_URL = (args['base-url'] ?? process.env.OPENAI_BASE_URL ?? 'http://localhost:11434/v1').replace(/\/+$/, '');
+const MODEL = args.model ?? process.env.RN_AGENTS_LOCAL_MODEL ?? 'qwen2.5-coder:14b';
+const REPO = path.resolve(args.repo ?? process.cwd());
+
+const c = {
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+};
+const die = (msg) => {
+  console.error(`\n  ${c.red('✗')} ${msg}\n`);
+  process.exit(1);
+};
+
+/* ---------------------------------------------------------------- 1. diff */
+
+function getDiff() {
+  if (args['diff-file']) {
+    const p = path.resolve(args['diff-file']);
+    if (!fs.existsSync(p)) die(`No such diff file: ${p}`);
+    return fs.readFileSync(p, 'utf8');
+  }
+
+  const git = (...a) => execFileSync('git', a, { cwd: REPO, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  try {
+    git('rev-parse', '--git-dir');
+  } catch {
+    die(`Not a git repository: ${REPO}\n    Pass --repo <path> or --diff-file <file>.`);
+  }
+
+  if (args.base) {
+    // Compare against the merge base, not the branch tip, so commits that
+    // landed on the base after you branched are not reported as your changes.
+    let mergeBase;
+    try {
+      mergeBase = git('merge-base', 'HEAD', args.base).trim();
+    } catch {
+      die(`Cannot resolve base "${args.base}". Is it a branch that exists locally?`);
+    }
+    return git('diff', `${mergeBase}...HEAD`);
+  }
+
+  // Uncommitted work: staged and unstaged, plus untracked files, since a
+  // brand-new component is exactly what you want reviewed.
+  const tracked = git('diff', 'HEAD');
+  const untracked = git('ls-files', '--others', '--exclude-standard').split('\n').filter(Boolean);
+  const extra = untracked
+    .filter((f) => /\.(ts|tsx|js|jsx|json|plist|xml|gradle|podspec)$/.test(f))
+    .map((f) => {
+      try {
+        return git('diff', '--no-index', '--', '/dev/null', f);
+      } catch (e) {
+        // --no-index exits 1 when files differ, which is the normal case here.
+        return e.stdout ?? '';
+      }
+    })
+    .join('\n');
+
+  return [tracked, extra].filter(Boolean).join('\n');
+}
+
+/* ------------------------------------------------------- 2. server preflight */
+
+async function preflight() {
+  const origin = BASE_URL.replace(/\/v1$/, '');
+
+  let tags;
+  try {
+    const r = await fetch(`${origin}/api/tags`, { signal: AbortSignal.timeout(4000) });
+    if (r.ok) tags = await r.json();
+  } catch {
+    /* Not Ollama, or not up — fall through to the generic probe below. */
+  }
+
+  if (!tags) {
+    try {
+      await fetch(`${BASE_URL}/models`, { signal: AbortSignal.timeout(4000) });
+      return null; // Reachable, but not Ollama — skip the model checks.
+    } catch {
+      die(
+        `Cannot reach a model server at ${BASE_URL}\n` +
+          `    Start Ollama with:  ollama serve\n` +
+          `    Or point elsewhere: --base-url http://host:port/v1`,
+      );
+    }
+  }
+
+  const available = (tags.models ?? []).map((m) => m.name);
+  if (!available.includes(MODEL)) {
+    const near = available.filter((m) => m.split(':')[0] === MODEL.split(':')[0]);
+    die(
+      `Model "${MODEL}" is not pulled.\n` +
+        (near.length ? `    Same family available: ${near.join(', ')}\n` : '') +
+        `    Pull it with:  ollama pull ${MODEL}\n` +
+        (available.length ? `    Or use one of: ${available.slice(0, 8).join(', ')}` : ''),
+    );
+  }
+  return origin;
+}
+
+/**
+ * The context check.
+ *
+ * `ollama show` reports the model's architectural limit, which is NOT the limit
+ * it will run at — `num_ctx` in the loaded parameters is. When the two disagree
+ * the smaller one wins, silently, by discarding the oldest tokens.
+ */
+async function contextWindow(origin) {
+  try {
+    const r = await fetch(`${origin}/api/show`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: MODEL }),
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!r.ok) return null;
+    const info = await r.json();
+
+    const architectural = Object.entries(info.model_info ?? {}).find(([k]) =>
+      k.endsWith('.context_length'),
+    )?.[1];
+
+    // An explicit num_ctx in the Modelfile parameters overrides the default.
+    const explicit = /(?:^|\n)\s*num_ctx\s+(\d+)/.exec(info.parameters ?? '')?.[1];
+
+    return {
+      architectural: architectural ? Number(architectural) : null,
+      configured: explicit ? Number(explicit) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/* ------------------------------------------------------------------ 3. run */
+
+const diff = getDiff();
+if (!diff.trim()) {
+  console.log(`\n  ${c.dim('No changes to audit.')}`);
+  console.log(`  ${c.dim('Try --base main, or --diff-file <file>.')}\n`);
+  process.exit(0);
+}
+
+const files = [...diff.matchAll(/^diff --git .* b\/(.+)$/gm)].map((m) => m[1]);
+console.log(`\n  ${c.bold('Local audit')}`);
+console.log(`  ${c.dim(`model  ${MODEL}`)}`);
+console.log(`  ${c.dim(`server ${BASE_URL}`)}`);
+console.log(`  ${c.dim(`repo   ${REPO}`)}`);
+console.log(`  ${c.dim(`diff   ${files.length} file(s), ${(diff.length / 1024).toFixed(1)} KB`)}`);
+
+const origin = await preflight();
+
+if (origin) {
+  const ctx = await contextWindow(origin);
+  // ~3.5 chars per token for source code, plus the agent instructions and
+  // reference material the audit prepends. Deliberately conservative: being
+  // wrong in this direction costs a warning, being wrong the other way costs
+  // a review that looks fine and checked nothing.
+  const estimate = Math.ceil(diff.length / 3.5) + 4000;
+  const effective = ctx?.configured ?? ctx?.architectural ?? null;
+
+  if (effective) {
+    const detail = ctx.configured
+      ? `num_ctx ${ctx.configured}`
+      : `default; model supports ${ctx.architectural}`;
+    console.log(`  ${c.dim(`context ~${estimate} tokens needed, ${effective} available (${detail})`)}`);
+
+    if (estimate > effective) {
+      console.error(
+        `\n  ${c.red('✗')} This diff will not fit in the context window.\n\n` +
+          `    Ollama does not error on overflow — it silently drops the oldest\n` +
+          `    tokens, which are the agent's instructions. The review would still\n` +
+          `    print findings and still say "Passed". It would mean nothing.\n\n` +
+          `    Fix it with one of:\n` +
+          `      • Raise the window:  OLLAMA_CONTEXT_LENGTH=32768 ollama serve\n` +
+          `      • Audit less at once: --base <branch> on a smaller range\n` +
+          `      • Use a hosted model for this one:\n` +
+          `          node action/index.mjs --diff-file <f> --provider anthropic\n`,
+      );
+      process.exit(1);
+    }
+    if (!ctx.configured && ctx.architectural >= 32768) {
+      console.log(
+        `  ${c.yellow('!')} ${c.dim(
+          'Ollama may still cap this at its own default. If findings look ' +
+            'ungrounded, set OLLAMA_CONTEXT_LENGTH and restart the server.',
+        )}`,
+      );
+    }
+  }
+}
+
+const tmp = path.join(os.tmpdir(), `rn-agents-local-${Date.now()}.diff`);
+fs.writeFileSync(tmp, diff);
+
+const passthrough = [];
+for (const k of ['fail-on', 'only', 'max-files', 'budget']) {
+  if (args[k]) passthrough.push(`--${k}`, args[k]);
+}
+
+const child = spawn(
+  process.execPath,
+  [path.join(ROOT, 'action', 'index.mjs'), '--diff-file', tmp, '--provider', 'openai', '--model', MODEL, ...passthrough],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      OPENAI_BASE_URL: BASE_URL,
+      // Any non-empty value satisfies the key check; a local server ignores it.
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'local',
+      // Budgeting is already disabled for localhost, but be explicit: a local
+      // model costs nothing and a dollar cap here is meaningless.
+      RN_AGENTS_TELEMETRY: process.env.RN_AGENTS_TELEMETRY ?? 'off',
+    },
+  },
+);
+
+child.on('exit', (code) => {
+  fs.rmSync(tmp, { force: true });
+  process.exit(code ?? 0);
+});

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -178,10 +178,92 @@ for (const a of agents) {
   test(`${a.id}: no non-ASCII stray characters in prose`, () => {
     // Allow common typography and the agent emoji; catch accidental CJK etc.
     const all = [a.body, ...a.references.map((r) => r.content)].join('\n');
-    const stray = all.match(/[　-鿿가-힯]/g);
+    const stray = all.match(/[\u3000-\u9fff\uac00-\ud7af]/g);
     assert(!stray, `found: ${stray?.slice(0, 5).join(' ')}`);
   });
 }
+
+test('.gitignore does not hide any generated dist output', () => {
+  // `.claude/` was added to ignore the local skills directory. Unanchored, it
+  // also matches `dist/claude-code/.claude/` — so an entire target's generated
+  // output became invisible to `git add`, and a release would have shipped a
+  // dist tree missing the newest agent. Anchor root-level entries with a
+  // leading slash.
+  const gitignore = fs.readFileSync(path.join(ROOT, '.gitignore'), 'utf8');
+  const offenders = gitignore
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#') && !l.startsWith('!'))
+    .filter((l) => !l.startsWith('/') && !l.includes('*'))
+    // A bare `foo/` or `foo` in .gitignore matches at every depth, so it can
+    // reach inside dist/. Anything that names a directory that exists under
+    // dist/ must be anchored.
+    .filter((l) => {
+      const bare = l.replace(/\/$/, '');
+      if (!bare || bare.includes('/')) return false;
+      let found = false;
+      const walk = (dir, depth) => {
+        if (found || depth > 4) return;
+        let entries;
+        try {
+          entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const e of entries) {
+          if (!e.isDirectory()) continue;
+          if (e.name === bare) {
+            found = true;
+            return;
+          }
+          walk(path.join(dir, e.name), depth + 1);
+        }
+      };
+      walk(path.join(ROOT, 'dist'), 0);
+      return found;
+    });
+
+  assert(
+    offenders.length === 0,
+    `unanchored .gitignore entries that also match inside dist/: ${offenders.join(', ')} ` +
+      '— prefix with "/" to scope them to the repository root',
+  );
+});
+
+test('no stray CJK characters anywhere in the repository source', () => {
+  // The per-agent sweep above covers agent prose only. Twice now a stray CJK
+  // character has been typed into a *source* file instead — once into the
+  // `legacy architecture` regex in this very file, where it silently narrowed a
+  // guard and nothing could see it. Source is scanned too. (Both sweeps write
+  // their ranges as \\u escapes so they do not flag themselves.)
+  const roots = ['scripts', 'action', 'mcp', 'evals'];
+  const CJK = /[\u3000-\u9fff\uac00-\ud7af]/g;
+  const hits = [];
+
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name === '.git') continue;
+        walk(full);
+        continue;
+      }
+      if (!/\.(mjs|js|ts|tsx|json)$/.test(e.name)) continue;
+      const text = fs.readFileSync(full, 'utf8');
+      const found = text.match(CJK);
+      if (found) hits.push(`${path.relative(ROOT, full)}: ${[...new Set(found)].slice(0, 5).join(' ')}`);
+    }
+  };
+
+  for (const r of roots) walk(path.join(ROOT, r));
+  assert(hits.length === 0, `stray CJK in source:\n    ${hits.join('\n    ')}`);
+});
 
 test('README documents every agent and states the right counts', () => {
   // The README said "Ten expert AI agents" and "57 reference documents" while
@@ -536,6 +618,91 @@ test('monorepo guidance prefers dependency resolution over resolver overrides', 
  * regular expression to recognise irony.
  */
 const FORBIDDEN_ABSOLUTES = [
+  {
+    claim: 'a fixed React Native floor for Reanimated 4',
+    patterns: [
+      /reanimated\s*4[^.]{0,50}(needs|requires|supports)[^.]{0,20}(react native\s*)?0\.7[0-7]/i,
+      /rn\s*(>=|≥)\s*0\.7[0-7]/i,
+      /(react native|rn)\s+0\.76\s+(or newer|and above|\+)/i,
+    ],
+    why: 'Support is a moving window per Reanimated minor, not a floor — 4.7.x drops RN 0.78. Read the compatibility table',
+  },
+  {
+    claim: 'captured React values frozen forever, with no mention of dependencies',
+    patterns: [
+      /(captured|capture)\s+by\s+copy[^.|]{0,30}frozen\s+at\s+creation/i,
+      /(usestate|state|props?)\s+(values?\s+)?(inside|in)\s+a?\s*worklet[^.|]{0,40}(always|permanently|forever)\s+stale/i,
+      /no\s+captured\s+component\s+state\b/i,
+      /captured\s+a\s+`?usestate`?\s+value\s+instead\s+of\s+a\s+shared\s+value/i,
+    ],
+    why: 'A Reanimated hook re-creates its worklet when its dependencies change, so the copy refreshes on re-render. What pins it is a frozen dependency list, a ref, or a value that must change between renders',
+  },
+  {
+    claim: 'a per-frame operation costing nothing',
+    patterns: [
+      /costs?\s+nothing\s+per\s+frame/i,
+      /(free|zero[- ]cost)\s+(per\s+frame|on\s+every\s+frame)/i,
+    ],
+    why: 'Nothing on a frame path is free. Say what it does and does not cost',
+  },
+  {
+    claim: 'the UI thread as an unconditional property of a library',
+    patterns: [
+      /animations?\s+must\s+run\s+on\s+the\s+ui\s+thread\b/i,
+      /worklets\s+run\s+on\s+the\s+ui\s+thread\s*\./i,
+      /\bgesture\s+handler\b[^.|]{0,30}runs\s+on\s+the\s+ui\s+thread\s*[,.]/i,
+    ],
+    why: 'Where code runs depends on the API and its configuration, not the library — useAnimatedStyle also runs once on JS, and core Animated needs useNativeDriver',
+  },
+  {
+    claim: 'the Babel plugin named only by its legacy path',
+    patterns: [
+      /rg\s+'reanimated\/plugin'/i,
+      /['"`]reanimated\/plugin['"`]\s+must\s+be\s+last/i,
+    ],
+    why: 'Reanimated 4 renamed it to react-native-worklets/plugin — a grep for the old name alone reports a correct config as broken',
+  },
+  {
+    claim: 'index keys remounting the tail of a list',
+    patterns: [
+      /(index|key=\{i\})[^.]{0,60}(whole tail|entire tail|tail)[^.]{0,30}(re-?mounts?|re-?animates?|re-?enters?)/i,
+      /(re-?mounts?|re-?animates?)[^.]{0,40}(every|all)\s+(items?|rows?)\s+after/i,
+      /items?\s+\d+\.\.n\s+["']?enter/i,
+    ],
+    why: 'React reuses the surviving positional keys; only the last index unmounts. The wrong row animates — the tail does not re-enter',
+  },
+  {
+    claim: 'Reanimated 4 on the legacy architecture',
+    patterns: [
+      /reanimated\s*4[^.]{0,60}(works|supported|runs)[^.]{0,30}(paper|legacy|old arch)/i,
+      /reanimated\s*4[^.]{0,60}supports?\s+(both|the legacy|paper)/i,
+    ],
+    why: 'Reanimated 4 is New Architecture only — it drops Paper entirely',
+  },
+  {
+    claim: 'runOnJS presented as current on 4.x',
+    patterns: [
+      /runOnJS\s+is\s+the\s+(current|recommended|correct)\s+/i,
+      /(use|prefer)\s+runOnJS\s+(in|on|with)\s+reanimated\s*4/i,
+    ],
+    why: 'runOnJS is deprecated in Reanimated 4 — scheduleOnRN, with un-curried arguments',
+  },
+  {
+    claim: 'worklets always run on the UI thread',
+    patterns: [
+      /worklets?\s+(always|automatically)\s+runs?\s+on\s+the\s+UI\s+thread/i,
+      /(guaranteed|always)\s+to\s+run\s+on\s+the\s+UI\s+thread/i,
+    ],
+    why: 'Without the Babel plugin a worklet silently runs on JS — that is the whole failure mode',
+  },
+  {
+    claim: 'a worklet sees current React state',
+    patterns: [
+      /worklets?\s+(can\s+)?(read|see|access)\s+(the\s+)?(current|latest)\s+(react\s+)?state/i,
+      /useState[^.]{0,40}(works|is fine|safe)\s+(inside|within)\s+a?\s*worklet/i,
+    ],
+    why: 'A worklet captures by copy at creation — captured state is frozen, which is the top bug in this area',
+  },
   {
     claim: 'sandbox receipts',
     patterns: [

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -25,7 +25,7 @@ const KNOWN_WHOLE_WORDS = new Set(['spec', 'orient', 'i18n', 'newarch', 'nx']);
 const { telemetryState, consentState, sanitise, capture, ALLOWED_PROPERTIES } = await import(
   path.join(ROOT, 'scripts/lib/telemetry.mjs')
 );
-const { loadCases, scoreOutput, gateReasons, DEFAULT_MIN_PASS_RATE, splitClauses, containsWholeTerm, isQuestionCase } = await import(
+const { loadCases, scoreOutput, scannableText, classifyFailure, validate: validateCases, undefinedCalls, stripCommentsAndStrings, gateReasons, DEFAULT_MIN_PASS_RATE, splitClauses, containsWholeTerm, isQuestionCase } = await import(
   path.join(ROOT, 'evals/run.mjs')
 );
 const os = await import('node:os');
@@ -263,6 +263,348 @@ test('no stray CJK characters anywhere in the repository source', () => {
 
   for (const r of roots) walk(path.join(ROOT, r));
   assert(hits.length === 0, `stray CJK in source:\n    ${hits.join('\n    ')}`);
+});
+
+test('scoring reads the findings, not the JSON envelope they arrived in', () => {
+  // scoreOutput used to receive the raw response. For a structured case that is
+  // a fenced JSON document, so patterns matched key names and syntax rather than
+  // advice — one real run reported a violation whose evidence was a ```json blob.
+  const parsed = {
+    findings: [
+      { severity: 'P0', title: 'Token stored in plaintext', why: 'AsyncStorage is not encrypted', fix: 'Use Keychain' },
+    ],
+    summary: 'One critical issue.',
+  };
+  const raw = '```json\n' + JSON.stringify({ findings: parsed.findings }, null, 2) + '\n```';
+
+  const text = scannableText(raw, parsed, false);
+  assert(text.includes('Token stored in plaintext'), 'the title must be scored');
+  assert(text.includes('AsyncStorage is not encrypted'), 'the why must be scored');
+  assert(text.includes('Use Keychain'), 'the fix must be scored');
+  assert(text.includes('One critical issue.'), 'the summary must be scored');
+
+  // The envelope is gone.
+  for (const noise of ['```json', '"findings"', '"severity"', '"title":', '"fix":']) {
+    assert(!text.includes(noise), `envelope leaked into the haystack: ${noise}`);
+  }
+
+  // Concretely: an expect term naming a JSON field no longer passes for free.
+  const def = { expect: [{ name: 'mentions a severity field', any: ['"severity"'] }], forbid: [] };
+  assert(
+    scoreOutput(text, def).expectPassed === 0,
+    'a JSON field name must not satisfy an expectation',
+  );
+  assert(raw.includes('"severity"'), 'fixture sanity: the field name is in the envelope');
+  assert(
+    scoreOutput(raw.toLowerCase(), def).expectPassed === 1,
+    'sanity: the raw envelope is exactly what used to satisfy it',
+  );
+});
+
+test('a prose answer is still scored on its raw text', () => {
+  // Question-style cases have no findings array. Routing them through the
+  // findings extractor would score them against an empty string and pass
+  // everything vacuously.
+  const raw = 'You should migrate to TanStack Query, but it is not free.';
+  eq(scannableText(raw, { findings: [], summary: '' }, true), raw);
+});
+
+test('a structured response with no findings scores as empty, not as its envelope', () => {
+  // The clean-case path. If an empty findings array fell back to the raw text,
+  // every clean case would be scored against the JSON that says it found
+  // nothing — and `"findings": []` contains the word "findings".
+  const raw = '```json\n{"findings": [], "summary": "No issues found."}\n```';
+  const text = scannableText(raw, { findings: [], summary: 'No issues found.' }, false);
+  eq(text, 'No issues found.');
+  assert(!text.includes('findings'), 'the envelope must not leak on the empty path');
+});
+
+test('findings keep their order so "leads with" rules still work', () => {
+  const parsed = {
+    findings: [
+      { severity: 'P1', title: 'Server state in the client store' },
+      { severity: 'P0', title: 'Token stored in plaintext' },
+    ],
+    summary: '',
+  };
+  const text = scannableText('', parsed, false);
+  assert(
+    text.indexOf('Server state') < text.indexOf('Token stored'),
+    'order must be preserved for ordering-sensitive rules',
+  );
+});
+
+test('a failed case is classified by what actually went wrong', () => {
+  // Every failure used to be reported as "missed expected findings". One real
+  // run listed state/server-state-in-store at 6/6 under that heading — it had
+  // matched everything and failed on a forbid rule.
+  const mk = (o) => ({ pass: false, score: { expectPassed: 0, expectTotal: 0, violations: [] }, ...o });
+
+  eq(classifyFailure(mk({ error: 'invalid JSON' })), 'errored');
+
+  eq(
+    classifyFailure(mk({ score: { expectPassed: 6, expectTotal: 6, violations: [{ name: 'x' }] } })),
+    'violation',
+    'complete answer + forbidden advice is not a miss',
+  );
+
+  eq(
+    classifyFailure(mk({ score: { expectPassed: 3, expectTotal: 6, violations: [{ name: 'x' }] } })),
+    'violation-and-missed',
+    'incomplete AND forbidden is both, and must still appear in the missed list',
+  );
+
+  eq(
+    classifyFailure(mk({ score: { expectPassed: 3, expectTotal: 6, violations: [] } })),
+    'missed',
+  );
+
+  // A clean case has no expectations at all; a violation there is still a
+  // violation, not a miss of zero things.
+  eq(
+    classifyFailure(mk({ score: { expectPassed: 0, expectTotal: 0, violations: [{ name: 'x' }] } })),
+    'violation',
+  );
+
+  // An error outranks everything — nothing else was scored.
+  eq(
+    classifyFailure(mk({ error: 'timeout', score: { expectPassed: 0, expectTotal: 6, violations: [{ name: 'x' }] } })),
+    'errored',
+  );
+
+  eq(classifyFailure({ pass: true }), null, 'a passing case has no failure class');
+});
+
+test('unlessAnywhere excuses a document-scoped claim, and only that', () => {
+  // Two rules assert an absence across the WHOLE answer ("without mentioning
+  // migration at all"), but their exception was clause-scoped — so they fired on
+  // answers that discussed migration one sentence later.
+  const rule = {
+    name: 'recommends the swap without mentioning migration at all',
+    all: ['mmkv'],
+    unlessAnywhere: '\\bmigrat\\w+',
+  };
+  const caught = (t) => scoreOutput(t, { forbid: [rule] }).violations.length > 0;
+
+  assert(caught('Swap AsyncStorage for MMKV.'), 'a bare recommendation is still a violation');
+  assert(
+    !caught('Swap AsyncStorage for MMKV. Note that you must migrate the existing data first.'),
+    'the cost discussed a sentence later must excuse it',
+  );
+  // Clause scope would NOT have excused that — this is the whole point.
+  const clauseScoped = { ...rule, unlessAnywhere: undefined, unlessPattern: '\\bmigrat\\w+' };
+  assert(
+    scoreOutput('Swap AsyncStorage for MMKV. Note that you must migrate the existing data first.', {
+      forbid: [clauseScoped],
+    }).violations.length > 0,
+    'sanity: clause scope is what was producing the false positive',
+  );
+});
+
+test('unlessAnywhere cannot be bolted onto a specific pattern', () => {
+  // Document scope is a real widening. Combining it with an already-precise
+  // pattern is how "a legitimate word anywhere excuses everything" comes back —
+  // the exact failure `unless` was removed for.
+  // loadCases expects <root>/<agent>/<case>/case.json.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-scope-'));
+  const caseDir = path.join(dir, 'security', 'demo');
+  fs.mkdirSync(caseDir, { recursive: true });
+  fs.writeFileSync(path.join(caseDir, 'input.tsx'), 'export const A = 1;\n');
+  fs.writeFileSync(
+    path.join(caseDir, 'case.json'),
+    JSON.stringify({
+      agent: 'rn-security',
+      title: 'scope check',
+      expect: [],
+      forbid: [
+        { name: 'bad', pattern: 'store the token', unlessAnywhere: 'keychain' },
+        { name: 'both', all: ['mmkv'], unlessPattern: 'migrat', unlessAnywhere: 'migrat' },
+      ],
+    }),
+  );
+
+  const problems = validateCases(loadCases(dir), agents);
+  assert(
+    problems.some((p) => /combines a specific "pattern"/.test(p)),
+    `pattern + unlessAnywhere must be rejected: ${problems.join(' | ')}`,
+  );
+  assert(
+    problems.some((p) => /pick one scope/.test(p)),
+    `both scopes at once must be rejected: ${problems.join(' | ')}`,
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('tightened forbid rules still catch the advice they exist for', () => {
+  // Each of these fired against a correct answer in a real run. Tightening a
+  // rule is only safe if the bad advice is still caught — otherwise the fix is
+  // just the rule giving up.
+  const load = (c) => JSON.parse(fs.readFileSync(path.join(ROOT, 'evals', c, 'case.json'), 'utf8'));
+  const ruleOf = (c, n) => {
+    const r = load(c).forbid.find((f) => f.name === n);
+    assert(r, `${c}: rule "${n}" not found`);
+    return r;
+  };
+  const check = (rule, bad, good) => {
+    const caught = (t) => scoreOutput(t.toLowerCase(), { forbid: [rule] }).violations.length > 0;
+    assert(caught(bad), `should still catch: ${bad}`);
+    assert(!caught(good), `should no longer fire on: ${good}`);
+  };
+
+  check(
+    ruleOf('observability/proguard-strips-sdk', 'blames the iOS side when the failure is Android-only'),
+    'The missing dSYM upload is the cause of the empty crash list.',
+    // Deliberately carries NO qualifier the unlessPattern could catch: a bare,
+    // neutral mention of the iOS pipeline. The first version of this test used
+    // "iOS crash reporting is unaffected", which the widened unlessPattern
+    // excused all by itself — so reverting the pattern to `dsym|ios (crash|
+    // symbolicat)` left the test green and proved nothing.
+    'Compare the behaviour with the dSYM pipeline on iOS to see the difference.',
+  );
+
+  check(
+    ruleOf('release/missing-sourcemaps', 'treats attaching the map as an artifact as sufficient'),
+    'Source maps are handled — the workflow already attaches them.',
+    'The source maps are uploaded to Sentry as part of the release step, which is what symbolication needs.',
+  );
+
+  check(
+    ruleOf('permissions/blocked-treated-as-denied', 'recommends re-requesting on mount or on every launch'),
+    'You should call request() on mount so the user sees the prompt again.',
+    // Plain description of the existing code, with no qualifier for the
+    // unlessPattern to catch — so this isolates the pattern change. The earlier
+    // version said "is currently requested on launch", and `currently` in the
+    // exception list excused it whichever pattern was in force.
+    'The code requests the permission on mount.',
+  );
+
+  check(
+    ruleOf('monorepo/duplicate-react', 'recommends deleting node_modules as the first step'),
+    'Start by running rm -rf node_modules and reinstalling.',
+    'First confirm the duplicate with npm ls react and inspect the resolved paths. ' +
+      'That tells you which package pulled the second copy. '.repeat(12) +
+      'Only then rm -rf node_modules and reinstall.',
+  );
+
+  check(
+    ruleOf('background/load-bearing-sync', 'recommends a foreground service to make polling reliable'),
+    'Use a foreground service so the sync runs reliably.',
+    'A foreground service is only appropriate for work the user can see, such as navigation.',
+  );
+});
+
+test('the fixture scanner sees calls through a namespace object', () => {
+  // evals/state/clean-auth-store called SecureStore.deleteItemAsync with no
+  // import, and --validate passed it. The call scan skipped anything preceded by
+  // a dot — correct for the *method*, but it meant the receiver was never
+  // checked at all. A clean case asserts there is nothing to report, so a
+  // fixture that does not compile penalises every model that reads it properly.
+  const src = "export async function logout() {\n  await SecureStore.deleteItemAsync('t');\n}\n";
+  assert(undefinedCalls(src, 'input.ts').includes('SecureStore'), 'undefined namespace must be reported');
+
+  const withImport = `import * as SecureStore from 'expo-secure-store';\n${src}`;
+  eq(undefinedCalls(withImport, 'input.ts').length, 0, 'a namespace import must satisfy it');
+});
+
+test('the fixture scanner ignores call-shaped prose in comments and strings', () => {
+  // Nine of the fourteen findings on the first run of the member-call scan were
+  // English sentences: "…the sheet is gone. Cancelling on unmount (…" parses as
+  // gone.Cancelling(.
+  const src = [
+    '// The spring is gone. Cancelling on unmount (see below) is what matters.',
+    '/* Compare with Foo.bar() in the other file. */',
+    'const msg = "call Baz.qux() to reset";',
+    'export const ok = 1;',
+  ].join('\n');
+  eq(undefinedCalls(src, 'input.ts').join(), '', `no prose should be reported: ${undefinedCalls(src, 'input.ts')}`);
+
+  // Real code next to that prose is still checked.
+  eq(undefinedCalls(`${src}\nMissingNs.go();\n`, 'input.ts').join(), 'MissingNs');
+});
+
+test('stripping preserves line structure', () => {
+  // Replacing with spaces rather than deleting keeps offsets stable, so a
+  // reported identifier still lines up with the source.
+  const src = 'const a = 1; // note\nconst b = "x";\n';
+  const out = stripCommentsAndStrings(src);
+  eq(out.length, src.length, 'length must be preserved');
+  eq(out.split('\n').length, src.split('\n').length, 'line count must be preserved');
+  assert(out.includes('const a = 1;'), 'code survives');
+  assert(!out.includes('note'), 'comment text is gone');
+});
+
+test('destructured callback params and namespace imports both count as bindings', () => {
+  eq(undefinedCalls("Linking.addEventListener('url', ({ url }) => url.split('/'));\nconst Linking = {};\n", 'input.ts').join(), '');
+});
+
+test('a forbid rule does not fire on the correct answer naming the failure mode', () => {
+  // "claims a promise can go unsettled" triggered on the bare word `hang`, with
+  // no exception at all. A correct review of a correct TurboModule names the
+  // failure mode precisely in order to rule it out — so the suite was punishing
+  // the answer it wanted.
+  const rule = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'evals/native-modules/clean-turbomodule/case.json'), 'utf8'),
+  ).forbid.find((f) => f.name.includes('unsettled'));
+  const caught = (t) => scoreOutput(t.toLowerCase(), { forbid: [rule] }).violations.length > 0;
+
+  assert(caught('If the native side throws, the promise can hang forever.'), 'the real claim is caught');
+  assert(caught('This will never resolve when the bridge is busy.'), 'the paraphrase is caught');
+
+  for (const correct of [
+    'Every path settles the promise, so it cannot hang.',
+    'There is no path that leaves the promise unsettled.',
+    'Both the resolve and reject branches are covered; the promise never hangs.',
+  ]) {
+    assert(!caught(correct), `must not fire on a correct answer: ${correct}`);
+  }
+});
+
+test('an exception is no narrower than the expectation it mirrors', () => {
+  // dependencies/deprecated-storage-swap expects "raises data migration for
+  // existing users" and forbids "recommends the swap without mentioning
+  // migration at all" — the same concept, asserted twice. Their vocabularies had
+  // drifted: the model said "existing users", which satisfied the expectation
+  // and did NOT excuse the violation, so one case reported both that the model
+  // raised migration and that it never mentioned it.
+  //
+  // The pairs are listed explicitly. There are two, and inferring the link from
+  // rule names would be guesswork of exactly the kind this suite keeps removing.
+  const pairs = [
+    {
+      case: 'dependencies/deprecated-storage-swap',
+      expect: 'raises data migration for existing users',
+      forbid: 'recommends the swap without mentioning migration at all',
+    },
+    {
+      case: 'state/server-state-in-store',
+      expect: null, // no mirrored expectation; the exception stands alone
+      forbid: 'presents the server-state migration as free',
+    },
+    {
+      case: 'animation/stale-worklet-closure',
+      expect: 'identifies the empty dependency array as what pins the captured values',
+      forbid: 'treats the wrong-item symptom as a list keying bug without the closure',
+    },
+  ];
+
+  for (const pair of pairs) {
+    if (!pair.expect) continue;
+    const def = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'evals', pair.case, 'case.json'), 'utf8'),
+    );
+    const e = def.expect.find((x) => x.name === pair.expect);
+    const f = def.forbid.find((x) => x.name === pair.forbid);
+    assert(e && f, `${pair.case}: pair not found`);
+    const exception = new RegExp(f.unlessAnywhere ?? f.unlessPattern, 'i');
+
+    for (const term of e.any ?? []) {
+      assert(
+        exception.test(term),
+        `${pair.case}: "${term}" satisfies the expectation "${pair.expect}" but does not ` +
+          `excuse "${pair.forbid}" — the case would report both at once`,
+      );
+    }
+  }
 });
 
 test('README documents every agent and states the right counts', () => {


### PR DESCRIPTION

- Add rn-animation (25th agent) with 5 references and 2 eval cases
- Thread placement is a property of the API, not the library
- Captured values refresh with dependencies; frozen lists and refs pin them
- Reanimated 4 support is a moving window per minor, not an RN floor
- Route legacy Animated/LayoutAnimation/PanResponder; read removed diff lines so deleting react-native-worklets/plugin is reviewed
- Gate babel.config.js on worklets content
- 8 FORBIDDEN_ABSOLUTES guards; CJK sweep extended to source